### PR TITLE
Add support for forge 1.17 entity models

### DIFF
--- a/js/io/project.js
+++ b/js/io/project.js
@@ -286,7 +286,7 @@ new Property(ModelProject, 'string', 'geometry_name', {
 });
 new Property(ModelProject, 'string', 'modded_entity_version', {
 	label: 'dialog.project.modded_entity_version',
-	default: '1.15',
+	default: '1.17',
 	condition: {formats: ['modded_entity']},
 	options() {
 		let options = {}


### PR DESCRIPTION
This adds a new forge 1.17 template to the modded entities. Mojang refactored the system quite a bit, and previous assumptions no longer work, so a few new expansion tokens / regex replacements have been added to account for this. Some simple testing shows it works on my end. More testing would be appreciated. I have published a build of this to my website which can be used for easier testing, see [https://sizableshrimp.me/blockbench/](https://sizableshrimp.me/blockbench/)