### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To launch Blockbench from source, you can clone the repository, navigate to the 
 
 ## Plugins
 
-Blockbench supports Javascript-based plugins. Learn more about creating plugins on [https://documentation.blockbench.net](https://documentation.blockbench.net).
+Blockbench supports Javascript-based plugins. Learn more about creating plugins on [https://www.blockbench.net/wiki/api/index](https://www.blockbench.net/wiki/api/index).
 
 
 


### PR DESCRIPTION
Just replace https://documentation.blockbench.net with the redirect destination link. The old link has expired SSL, and a browser will warn you.

You can see that it has expired:

![](https://user-images.githubusercontent.com/34268371/177140165-1d3e9cf7-bc82-47bf-b347-0eee0938a40d.png)
https://www.ssllabs.com/ssltest/analyze.html?d=documentation.blockbench.net