### PR TITLE
Check for a valid file extension when exporting

### DIFF
--- a/js/file_system.js
+++ b/js/file_system.js
@@ -276,7 +276,7 @@ Object.assign(Blockbench, {
 		if (Blockbench.isWeb) {
 			var file_name = options.name || 'file';
 			var extension = pathToExtension(file_name);
-			if (!options.extensions.includes(extension) && options.extensions && options.extensions[0]) {
+			if (options.extensions instanceof Array && !options.extensions.includes(extension) && options.extensions[0]) {
 				file_name += '.' + options.extensions[0];
 			}
 			if (options.custom_writer) {
@@ -327,7 +327,7 @@ Object.assign(Blockbench, {
 				StateMemory.save('dialog_paths')
 			}
 			var extension = pathToExtension(file_path);
-			if (!options.extensions.includes(extension) && options.extensions && options.extensions[0]) {
+			if (options.extensions instanceof Array && !options.extensions.includes(extension) && options.extensions[0]) {
 				file_path += '.'+options.extensions[0]
 			}
 			Blockbench.writeFile(file_path, options, cb)

--- a/js/file_system.js
+++ b/js/file_system.js
@@ -275,7 +275,8 @@ Object.assign(Blockbench, {
 		*/
 		if (Blockbench.isWeb) {
 			var file_name = options.name || 'file';
-			if (options.extensions && file_name.substr(-options.extensions[0].length) != options.extensions[0]) {
+			var extension = pathToExtension(file_name);
+			if (!options.extensions.includes(extension) && options.extensions && options.extensions[0]) {
 				file_name += '.' + options.extensions[0];
 			}
 			if (options.custom_writer) {
@@ -326,7 +327,7 @@ Object.assign(Blockbench, {
 				StateMemory.save('dialog_paths')
 			}
 			var extension = pathToExtension(file_path);
-			if (!extension && options.extensions && options.extensions[0]) {
+			if (!options.extensions.includes(extension) && options.extensions && options.extensions[0]) {
 				file_path += '.'+options.extensions[0]
 			}
 			Blockbench.writeFile(file_path, options, cb)


### PR DESCRIPTION
## Aim
Fixes #1485.

### Previous Behaviour
In desktop mode, Blockbench would only add a valid file extension if `pathToExtension` couldn't find an extension. 

In web mode, Blockbench would only add a valid file extension if the file name ended with the first extension in the `options.extensions` array.

## Solution
When exporting a file, Blockbench will now add a valid extension if it is missing one.