### PR TITLE
Model formats can now disable cube rotation snapping

### DIFF
--- a/js/copy_paste.js
+++ b/js/copy_paste.js
@@ -365,7 +365,8 @@ const Clipbench = {
 				if (cube instanceof Cube == false) return;
 				if (!cube.rotation.allEqual(0)) {
 					var axis = getAxisNumber(cube.rotationAxis()) || 0;
-					var angle = limitNumber( Math.round(cube.rotation[axis]/22.5)*22.5, -45, 45 );
+					var cube_rotation = Format.rotation_snap ? Math.round(cube_rotation/22.5)*22.5 : cube.rotation[axis];
+					var angle = limitNumber( cube_rotation, -45, 45 );
 					cube.rotation.V3_set(0, 0, 0);
 					cube.rotation[axis] = angle;
 				}

--- a/js/copy_paste.js
+++ b/js/copy_paste.js
@@ -365,7 +365,7 @@ const Clipbench = {
 				if (cube instanceof Cube == false) return;
 				if (!cube.rotation.allEqual(0)) {
 					var axis = getAxisNumber(cube.rotationAxis()) || 0;
-					var cube_rotation = Format.rotation_snap ? Math.round(cube_rotation/22.5)*22.5 : cube.rotation[axis];
+					var cube_rotation = Format.rotation_snap ? Math.round(cube.rotation[axis]/22.5)*22.5 : cube.rotation[axis];
 					var angle = limitNumber( cube_rotation, -45, 45 );
 					cube.rotation.V3_set(0, 0, 0);
 					cube.rotation[axis] = angle;

--- a/js/io/format.js
+++ b/js/io/format.js
@@ -204,7 +204,8 @@ class ModelFormat {
 			Cube.all.forEach(cube => {
 				if (!cube.rotation.allEqual(0)) {
 					var axis = (cube.rotation_axis && getAxisNumber(cube.rotation_axis)) || 0;
-					var angle = limitNumber( Math.round(cube.rotation[axis]/22.5)*22.5, -45, 45 );
+					var cube_rotation = Format.rotation_snap ? Math.round(cube_rotation/22.5)*22.5 : cube.rotation[axis];
+					var angle = limitNumber( cube_rotation, -45, 45 );
 					cube.rotation.V3_set(0, 0, 0)
 					cube.rotation[axis] = angle;
 				}

--- a/js/io/format.js
+++ b/js/io/format.js
@@ -252,6 +252,7 @@ new Property(ModelFormat, 'boolean', 'meshes');
 new Property(ModelFormat, 'boolean', 'texture_meshes');
 new Property(ModelFormat, 'boolean', 'locators');
 new Property(ModelFormat, 'boolean', 'rotation_limit');
+new Property(ModelFormat, 'boolean', 'rotation_snap', {default: true});
 new Property(ModelFormat, 'boolean', 'uv_rotation');
 new Property(ModelFormat, 'boolean', 'java_face_properties');
 new Property(ModelFormat, 'boolean', 'select_texture_for_particles');

--- a/js/io/format.js
+++ b/js/io/format.js
@@ -253,7 +253,7 @@ new Property(ModelFormat, 'boolean', 'meshes');
 new Property(ModelFormat, 'boolean', 'texture_meshes');
 new Property(ModelFormat, 'boolean', 'locators');
 new Property(ModelFormat, 'boolean', 'rotation_limit');
-new Property(ModelFormat, 'boolean', 'rotation_snap', {default: true});
+new Property(ModelFormat, 'boolean', 'rotation_snap');
 new Property(ModelFormat, 'boolean', 'uv_rotation');
 new Property(ModelFormat, 'boolean', 'java_face_properties');
 new Property(ModelFormat, 'boolean', 'select_texture_for_particles');

--- a/js/io/format.js
+++ b/js/io/format.js
@@ -204,7 +204,7 @@ class ModelFormat {
 			Cube.all.forEach(cube => {
 				if (!cube.rotation.allEqual(0)) {
 					var axis = (cube.rotation_axis && getAxisNumber(cube.rotation_axis)) || 0;
-					var cube_rotation = Format.rotation_snap ? Math.round(cube_rotation/22.5)*22.5 : cube.rotation[axis];
+					var cube_rotation = Format.rotation_snap ? Math.round(cube.rotation[axis]/22.5)*22.5 : cube.rotation[axis];
 					var angle = limitNumber( cube_rotation, -45, 45 );
 					cube.rotation.V3_set(0, 0, 0)
 					cube.rotation[axis] = angle;

--- a/js/io/formats/java_block.js
+++ b/js/io/formats/java_block.js
@@ -486,6 +486,7 @@ var format = new ModelFormat({
 	vertex_color_ambient_occlusion: true,
 	rotate_cubes: true,
 	rotation_limit: true,
+	rotation_snap: true,
 	optional_box_uv: true,
 	uv_rotation: true,
 	java_face_properties: true,

--- a/js/modeling/transform.js
+++ b/js/modeling/transform.js
@@ -837,7 +837,7 @@ function moveElementsInSpace(difference, axis) {
 
 //Rotate
 function getRotationInterval(event) {
-	if (Format.rotation_limit) {
+	if (Format.rotation_limit && Format.rotation_snap) {
 		return 22.5;
 	} else if ((event.shiftKey || Pressing.overrides.shift) && (event.ctrlOrCmd || Pressing.overrides.ctrl)) {
 		return 0.25;
@@ -985,13 +985,16 @@ function rotateOnAxis(modify, axis, slider) {
 				obj.rotation[(axis+1)%3] = 0
 				obj.rotation[(axis+2)%3] = 0
 				//Limit Angle
-				obj_val = Math.round(obj_val/22.5)*22.5
+				if (Format.rotation_snap) {
+					obj_val = Math.round(obj_val/22.5)*22.5
+				}
 				if (obj_val > 45 || obj_val < -45) {
 	
 					let f = obj_val > 45
 					let can_roll = obj.roll(axis, f!=(axis==1) ? 1 : 3);
 					if (can_roll) {
-						obj_val = f ? -22.5 : 22.5;
+						let roll_angle = Format.rotation_snap ? 22.5 : 90 - Math.abs(obj_val)
+						obj_val = f ? -roll_angle : roll_angle;
 					} else {
 						obj_val = Math.clamp(obj_val, -45, 45);
 					}

--- a/js/modeling/transform.js
+++ b/js/modeling/transform.js
@@ -837,7 +837,7 @@ function moveElementsInSpace(difference, axis) {
 
 //Rotate
 function getRotationInterval(event) {
-	if (Format.rotation_limit && Format.rotation_snap) {
+	if (Format.rotation_snap) {
 		return 22.5;
 	} else if ((event.shiftKey || Pressing.overrides.shift) && (event.ctrlOrCmd || Pressing.overrides.ctrl)) {
 		return 0.25;


### PR DESCRIPTION
I'm currently working on a Minecraft mod that adds in a custom json model format. It's essentially an extension of the default vanilla format and it removes the 22.5 step limitation, however it keeps the axis restriction. I am also creating a plugin so models can be designed with the new format, unfortunately I ran into a wall developing the plugin where it's pretty much impossible for me to remove the step limitation for my format. I've tried patching and tons of other work arounds but there was always new bugs introduced doing so.

Hence why this PR is being created. I've kept changes to a minimum and ensured existing formats don't break.