### PR TITLE
feat: saved state changed event

### DIFF
--- a/js/io/project.js
+++ b/js/io/project.js
@@ -103,6 +103,12 @@ class ModelProject {
 	}
 	set saved(saved) {
 		this._saved = saved;
+
+		// Dispatch an event to allow other scripts to react to the change
+		Blockbench.dispatchEvent('saved_state_changed', { 
+			project: this, 
+			saved: saved
+		});
 		if (Project == this) {
 			setProjectTitle(this.name);
 		}


### PR DESCRIPTION
## Description
This event might make sense to have in core. I've originally implemented it on our fork to update the unsaved file indicator within bridge.'s own UI to accurately reflect Blockbench's internal state.

Feel free to close if you don't think it's a good fit.