### PR TITLE
feat: listen once

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -400,6 +400,27 @@ const Blockbench = {
 	on(event_name, cb) {
 		return Blockbench.addListener(event_name, cb) 
 	},
+	
+	/**
+	 * Listen for an event only once
+	 */
+	once(event_names, cb) {
+		/**
+		 * Blockbench.addListener supports registering multiple, space-separated events at once
+		 * We are parsing out a list of event names here to later unregister them correctly
+		 */ 
+		const events = event_names.split(' ');
+
+		const listener = (data) => {
+			cb(data);
+			// Remove all event listeners
+			events.forEach(event_name => {
+				Blockbench.removeListener(event_name, listener);
+			});
+		}
+
+		return Blockbench.on(event_names, listener);
+	},
 	removeListener(event_name, cb) {
 		if (!this.events[event_name]) return;
 		this.events[event_name].remove(cb);

--- a/js/io/codec.js
+++ b/js/io/codec.js
@@ -124,6 +124,18 @@ class Codec {
 		}
 		this.events[event_name].safePush(cb)
 	}
+
+	/**
+	 * Listen for an event only once
+	 */
+	once(event_name, cb) {
+		const listener = (data) => {
+			cb(data);
+			this.removeListener(event_name, listener);
+		}
+
+		return this.on(event_name, listener);
+	}
 	removeListener(event_name, cb) {
 		if (this.events[event_name]) {
 			this.events[event_name].remove(cb);


### PR DESCRIPTION
## Description
Listening to an event only once is a common convenience feature within event systems.

I've only implemented this where it made sense for bridge. rn but maybe Blockbench should have a common EventSystem class that other classes throughout the app can inherit from (therefore marking this PR as a draft for now). Having a common event system would keep the code a lot **DRY**-er.