### PR TITLE
Add link to github, for "All contributors" on about panel

### DIFF
--- a/js/interface/about.js
+++ b/js/interface/about.js
@@ -81,7 +81,7 @@ BARS.defineActions(() => {
 							<h4>SPECIAL THANKS TO</h4>
 							<ul class="multi_column_list special_thanks_mentions">
 								<li>Mojang Studios</li>
-								<li>All contributors</li>
+								<li><a class="open-in-browser" href="https://github.com/JannisX11/blockbench/graphs/contributors">All contributors</a></li>
 								<li>The community moderators</li>
 								<li>All donators</li>
 								<li>All translators</li>


### PR DESCRIPTION
This PR add link (https://github.com/JannisX11/blockbench/graphs/contributors) for "All contributors" on about panel.

![image](https://user-images.githubusercontent.com/40738104/204781589-0ed90381-c437-4a9c-a148-8071ffe66fa2.png)
