### PR TITLE
CSS Layer Support for Isolated Styling

### DIFF
--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -1,4 +1,5 @@
 /*Dialog*/
+@layer app {
 	#blackout {
 		display: none;
 		position: absolute;
@@ -1671,3 +1672,4 @@
 		margin-left: 8px;
 		white-space: nowrap;
 	}
+}

--- a/css/fontawesome.css
+++ b/css/fontawesome.css
@@ -3,6 +3,7 @@
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  * Copyright 2022 Fonticons, Inc.
  */
+@layer app {
  .fa {
   font-family: var(--fa-style-family, "Font Awesome 6 Free");
   font-weight: var(--fa-style, 900); }
@@ -6973,3 +6974,4 @@ readers do not read off random characters that represent icons */
 .fas {
   font-family: 'Font Awesome 6 Free';
   font-weight: 900; }
+}

--- a/css/general.css
+++ b/css/general.css
@@ -1,4 +1,5 @@
 /*Defaults*/
+@layer app {
 	div.tool.wide {
 		width: 72px;
 		padding: 1px 0;
@@ -722,3 +723,4 @@
 		padding: 0;
 		opacity: 1;
 	}
+}

--- a/css/jquery-ui.min.css
+++ b/css/jquery-ui.min.css
@@ -4,508 +4,510 @@
 * To view and modify this theme, visit http://jqueryui.com/themeroller/?scope=&folderName=base&cornerRadiusShadow=8px&offsetLeftShadow=0px&offsetTopShadow=0px&thicknessShadow=5px&opacityShadow=30&bgImgOpacityShadow=0&bgTextureShadow=flat&bgColorShadow=666666&opacityOverlay=30&bgImgOpacityOverlay=0&bgTextureOverlay=flat&bgColorOverlay=aaaaaa&iconColorError=cc0000&fcError=5f3f3f&borderColorError=f1a899&bgTextureError=flat&bgColorError=fddfdf&iconColorHighlight=777620&fcHighlight=777620&borderColorHighlight=dad55e&bgTextureHighlight=flat&bgColorHighlight=fffa90&iconColorActive=ffffff&fcActive=ffffff&borderColorActive=003eff&bgTextureActive=flat&bgColorActive=007fff&iconColorHover=555555&fcHover=2b2b2b&borderColorHover=cccccc&bgTextureHover=flat&bgColorHover=ededed&iconColorDefault=777777&fcDefault=454545&borderColorDefault=c5c5c5&bgTextureDefault=flat&bgColorDefault=f6f6f6&iconColorContent=444444&fcContent=333333&borderColorContent=dddddd&bgTextureContent=flat&bgColorContent=ffffff&iconColorHeader=444444&fcHeader=333333&borderColorHeader=dddddd&bgTextureHeader=flat&bgColorHeader=e9e9e9&cornerRadius=3px&fwDefault=normal&fsDefault=1em&ffDefault=Arial%2CHelvetica%2Csans-serif
 * Copyright jQuery Foundation and other contributors; Licensed MIT */
 
-.ui-draggable-handle {
-	-ms-touch-action: none;
-	touch-action: none
-}
-
-.ui-helper-hidden {
-	display: none
-}
-
-.ui-helper-hidden-accessible {
-	border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px
-}
-
-.ui-helper-reset {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	outline: 0;
-	line-height: 1.3;
-	text-decoration: none;
-	font-size: 100%;
-	list-style: none
-}
-
-.ui-helper-clearfix:before,
-.ui-helper-clearfix:after {
-	content: "";
-	display: table;
-	border-collapse: collapse
-}
-
-.ui-helper-clearfix:after {
-	clear: both
-}
-
-.ui-helper-zfix {
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	position: absolute;
-	opacity: 0;
-	filter: Alpha(Opacity=0)
-}
-
-.ui-front {
-	z-index: 100
-}
-
-.ui-state-disabled {
-	cursor: default!important;
-	pointer-events: none
-}
-
-.ui-icon {
-	display: inline-block;
-	vertical-align: middle;
-	margin-top: -.25em;
-	position: relative;
-	text-indent: -99999px;
-	overflow: hidden;
-	background-repeat: no-repeat
-}
-
-.ui-widget-icon-block {
-	left: 50%;
-	margin-left: -8px;
-	display: block
-}
-
-.ui-widget-overlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%
-}
-
-.ui-resizable {
-	position: relative
-}
-
-.ui-resizable-handle {
-	position: absolute;
-	font-size: 0.1px;
-	display: block;
-	-ms-touch-action: none;
-	touch-action: none
-}
-
-.ui-resizable-disabled .ui-resizable-handle,
-.ui-resizable-autohide .ui-resizable-handle {
-	display: none
-}
-
-.ui-resizable-n {
-	cursor: n-resize;
-	height: 7px;
-	width: 100%;
-	top: -5px;
-	left: 0
-}
-
-.ui-resizable-s {
-	cursor: s-resize;
-	height: 7px;
-	width: 100%;
-	bottom: -5px;
-	left: 0
-}
-
-.ui-resizable-e {
-	cursor: e-resize;
-	width: 7px;
-	right: -5px;
-	top: 0;
-	height: 100%
-}
-
-.ui-resizable-w {
-	cursor: w-resize;
-	width: 7px;
-	left: -5px;
-	top: 0;
-	height: 100%
-}
-
-.ui-resizable-se {
-	cursor: se-resize;
-	width: 16px;
-	height: 16px;
-	right: -5px;
-	bottom: -5px
-}
-
-.ui-resizable-sw {
-	cursor: sw-resize;
-	width: 16px;
-	height: 16px;
-	left: -5px;
-	bottom: -5px
-}
-
-.ui-resizable-nw {
-	cursor: nw-resize;
-	width: 16px;
-	height: 16px;
-	left: -5px;
-	top: -5px
-}
-
-.ui-resizable-ne {
-	cursor: ne-resize;
-	width: 16px;
-	height: 16px;
-	right: -5px;
-	top: -5px
-}
-
-.ui-selectable {
-	-ms-touch-action: none;
-	touch-action: none
-}
-
-.ui-selectable-helper {
-	position: absolute;
-	z-index: 100;
-	border: 1px dotted black
-}
-
-.ui-sortable-handle {
-	-ms-touch-action: none;
-	touch-action: none
-}
-
-.ui-accordion .ui-accordion-header {
-	display: block;
-	cursor: pointer;
-	position: relative;
-	margin: 2px 0 0 0;
-	padding: .5em .5em .5em .7em;
-	font-size: 100%
-}
-
-.ui-accordion .ui-accordion-content {
-	padding: 1em 2.2em;
-	border-top: 0;
-	overflow: auto
-}
-
-.ui-autocomplete {
-	position: absolute;
-	top: 0;
-	left: 0;
-	cursor: default
-}
-
-.ui-dialog .ui-resizable-se,
-.ui-dialog .ui-resizable-sw,
-.ui-dialog .ui-resizable-ne,
-.ui-dialog .ui-resizable-nw {
-	width: 7px;
-	height: 7px
-}
-
-.ui-dialog .ui-resizable-se {
-	right: 0;
-	bottom: 0
-}
-
-.ui-dialog .ui-resizable-sw {
-	left: 0;
-	bottom: 0
-}
-
-.ui-dialog .ui-resizable-ne {
-	right: 0;
-	top: 0
-}
-
-.ui-dialog .ui-resizable-nw {
-	left: 0;
-	top: 0
-}
-
-.ui-draggable .ui-dialog-titlebar {
-	cursor: move
-}
-
-.ui-progressbar {
-	height: 2em;
-	text-align: left;
-	overflow: hidden
-}
-
-.ui-progressbar .ui-progressbar-value {
-	margin: -1px;
-	height: 100%
-}
-
-.ui-progressbar .ui-progressbar-overlay {
-	background: url("data:image/gif;base64,R0lGODlhKAAoAIABAAAAAP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJAQABACwAAAAAKAAoAAACkYwNqXrdC52DS06a7MFZI+4FHBCKoDeWKXqymPqGqxvJrXZbMx7Ttc+w9XgU2FB3lOyQRWET2IFGiU9m1frDVpxZZc6bfHwv4c1YXP6k1Vdy292Fb6UkuvFtXpvWSzA+HycXJHUXiGYIiMg2R6W459gnWGfHNdjIqDWVqemH2ekpObkpOlppWUqZiqr6edqqWQAAIfkECQEAAQAsAAAAACgAKAAAApSMgZnGfaqcg1E2uuzDmmHUBR8Qil95hiPKqWn3aqtLsS18y7G1SzNeowWBENtQd+T1JktP05nzPTdJZlR6vUxNWWjV+vUWhWNkWFwxl9VpZRedYcflIOLafaa28XdsH/ynlcc1uPVDZxQIR0K25+cICCmoqCe5mGhZOfeYSUh5yJcJyrkZWWpaR8doJ2o4NYq62lAAACH5BAkBAAEALAAAAAAoACgAAAKVDI4Yy22ZnINRNqosw0Bv7i1gyHUkFj7oSaWlu3ovC8GxNso5fluz3qLVhBVeT/Lz7ZTHyxL5dDalQWPVOsQWtRnuwXaFTj9jVVh8pma9JjZ4zYSj5ZOyma7uuolffh+IR5aW97cHuBUXKGKXlKjn+DiHWMcYJah4N0lYCMlJOXipGRr5qdgoSTrqWSq6WFl2ypoaUAAAIfkECQEAAQAsAAAAACgAKAAAApaEb6HLgd/iO7FNWtcFWe+ufODGjRfoiJ2akShbueb0wtI50zm02pbvwfWEMWBQ1zKGlLIhskiEPm9R6vRXxV4ZzWT2yHOGpWMyorblKlNp8HmHEb/lCXjcW7bmtXP8Xt229OVWR1fod2eWqNfHuMjXCPkIGNileOiImVmCOEmoSfn3yXlJWmoHGhqp6ilYuWYpmTqKUgAAIfkECQEAAQAsAAAAACgAKAAAApiEH6kb58biQ3FNWtMFWW3eNVcojuFGfqnZqSebuS06w5V80/X02pKe8zFwP6EFWOT1lDFk8rGERh1TTNOocQ61Hm4Xm2VexUHpzjymViHrFbiELsefVrn6XKfnt2Q9G/+Xdie499XHd2g4h7ioOGhXGJboGAnXSBnoBwKYyfioubZJ2Hn0RuRZaflZOil56Zp6iioKSXpUAAAh+QQJAQABACwAAAAAKAAoAAACkoQRqRvnxuI7kU1a1UU5bd5tnSeOZXhmn5lWK3qNTWvRdQxP8qvaC+/yaYQzXO7BMvaUEmJRd3TsiMAgswmNYrSgZdYrTX6tSHGZO73ezuAw2uxuQ+BbeZfMxsexY35+/Qe4J1inV0g4x3WHuMhIl2jXOKT2Q+VU5fgoSUI52VfZyfkJGkha6jmY+aaYdirq+lQAACH5BAkBAAEALAAAAAAoACgAAAKWBIKpYe0L3YNKToqswUlvznigd4wiR4KhZrKt9Upqip61i9E3vMvxRdHlbEFiEXfk9YARYxOZZD6VQ2pUunBmtRXo1Lf8hMVVcNl8JafV38aM2/Fu5V16Bn63r6xt97j09+MXSFi4BniGFae3hzbH9+hYBzkpuUh5aZmHuanZOZgIuvbGiNeomCnaxxap2upaCZsq+1kAACH5BAkBAAEALAAAAAAoACgAAAKXjI8By5zf4kOxTVrXNVlv1X0d8IGZGKLnNpYtm8Lr9cqVeuOSvfOW79D9aDHizNhDJidFZhNydEahOaDH6nomtJjp1tutKoNWkvA6JqfRVLHU/QUfau9l2x7G54d1fl995xcIGAdXqMfBNadoYrhH+Mg2KBlpVpbluCiXmMnZ2Sh4GBqJ+ckIOqqJ6LmKSllZmsoq6wpQAAAh+QQJAQABACwAAAAAKAAoAAAClYx/oLvoxuJDkU1a1YUZbJ59nSd2ZXhWqbRa2/gF8Gu2DY3iqs7yrq+xBYEkYvFSM8aSSObE+ZgRl1BHFZNr7pRCavZ5BW2142hY3AN/zWtsmf12p9XxxFl2lpLn1rseztfXZjdIWIf2s5dItwjYKBgo9yg5pHgzJXTEeGlZuenpyPmpGQoKOWkYmSpaSnqKileI2FAAACH5BAkBAAEALAAAAAAoACgAAAKVjB+gu+jG4kORTVrVhRlsnn2dJ3ZleFaptFrb+CXmO9OozeL5VfP99HvAWhpiUdcwkpBH3825AwYdU8xTqlLGhtCosArKMpvfa1mMRae9VvWZfeB2XfPkeLmm18lUcBj+p5dnN8jXZ3YIGEhYuOUn45aoCDkp16hl5IjYJvjWKcnoGQpqyPlpOhr3aElaqrq56Bq7VAAAOw==");
-	height: 100%;
-	filter: alpha(opacity=25);
-	opacity: 0.25
-}
-
-.ui-progressbar-indeterminate .ui-progressbar-value {
-	background-image: none
-}
-
-.ui-tooltip {
-	padding: 8px;
-	position: absolute;
-	z-index: 9999;
-	max-width: 300px
-}
-
-body .ui-tooltip {
-	border-width: 2px
-}
-
-.ui-widget {
-	font-family: Arial, Helvetica, sans-serif;
-	font-size: 1em
-}
-
-.ui-widget .ui-widget {
-	font-size: 1em
-}
-
-.ui-widget input,
-.ui-widget select,
-.ui-widget textarea,
-.ui-widget button {
-	font-family: Arial, Helvetica, sans-serif;
-	font-size: 1em
-}
-
-.ui-widget.ui-widget-content {
-	border: 1px solid #c5c5c5
-}
-
-.ui-widget-content {
-	border: 1px solid #ddd;
-	background: #fff;
-	color: #333
-}
-
-.ui-widget-content a {
-	color: #333
-}
-
-.ui-widget-header {
-	border: 1px solid #ddd;
-	background: #e9e9e9;
-	color: #333;
-	font-weight: bold
-}
-
-.ui-widget-header a {
-	color: #333
-}
-
-.ui-state-default,
-.ui-widget-content .ui-state-default,
-.ui-widget-header .ui-state-default,
-.ui-button,
-html .ui-button.ui-state-disabled:hover,
-html .ui-button.ui-state-disabled:active {
-	border: 1px solid #c5c5c5;
-	background: #f6f6f6;
-	font-weight: normal;
-	color: #454545
-}
-
-.ui-state-default a,
-.ui-state-default a:link,
-.ui-state-default a:visited,
-a.ui-button,
-a:link.ui-button,
-a:visited.ui-button,
-.ui-button {
-	color: #454545;
-	text-decoration: none
-}
-
-.ui-state-hover,
-.ui-widget-content .ui-state-hover,
-.ui-widget-header .ui-state-hover,
-.ui-state-focus,
-.ui-widget-content .ui-state-focus,
-.ui-widget-header .ui-state-focus,
-.ui-button:hover,
-.ui-button:focus {
-	border: 1px solid #ccc;
-	background: #ededed;
-	font-weight: normal;
-	color: #2b2b2b
-}
-
-.ui-state-hover a,
-.ui-state-hover a:hover,
-.ui-state-hover a:link,
-.ui-state-hover a:visited,
-.ui-state-focus a,
-.ui-state-focus a:hover,
-.ui-state-focus a:link,
-.ui-state-focus a:visited,
-a.ui-button:hover,
-a.ui-button:focus {
-	color: #2b2b2b;
-	text-decoration: none
-}
-
-.ui-visual-focus {
-	box-shadow: 0 0 3px 1px rgb(94, 158, 214)
-}
-
-.ui-state-active,
-.ui-widget-content .ui-state-active,
-.ui-widget-header .ui-state-active,
-a.ui-button:active,
-.ui-button:active,
-.ui-button.ui-state-active:hover {
-	border: 1px solid #003eff;
-	background: #007fff;
-	font-weight: normal;
-	color: #fff
-}
-
-.ui-icon-background,
-.ui-state-active .ui-icon-background {
-	border: #003eff;
-	background-color: #fff
-}
-
-.ui-state-active a,
-.ui-state-active a:link,
-.ui-state-active a:visited {
-	color: #fff;
-	text-decoration: none
-}
-
-.ui-state-highlight,
-.ui-widget-content .ui-state-highlight,
-.ui-widget-header .ui-state-highlight {
-	border: 1px solid #dad55e;
-	background: #fffa90;
-	color: #777620
-}
-
-.ui-state-checked {
-	border: 1px solid #dad55e;
-	background: #fffa90
-}
-
-.ui-state-highlight a,
-.ui-widget-content .ui-state-highlight a,
-.ui-widget-header .ui-state-highlight a {
-	color: #777620
-}
-
-.ui-state-error,
-.ui-widget-content .ui-state-error,
-.ui-widget-header .ui-state-error {
-	border: 1px solid #f1a899;
-	background: #fddfdf;
-	color: #5f3f3f
-}
-
-.ui-state-error a,
-.ui-widget-content .ui-state-error a,
-.ui-widget-header .ui-state-error a {
-	color: #5f3f3f
-}
-
-.ui-state-error-text,
-.ui-widget-content .ui-state-error-text,
-.ui-widget-header .ui-state-error-text {
-	color: #5f3f3f
-}
-
-.ui-priority-primary,
-.ui-widget-content .ui-priority-primary,
-.ui-widget-header .ui-priority-primary {
-	font-weight: bold
-}
-
-.ui-priority-secondary,
-.ui-widget-content .ui-priority-secondary,
-.ui-widget-header .ui-priority-secondary {
-	opacity: .7;
-	filter: Alpha(Opacity=70);
-	font-weight: normal
-}
-
-.ui-state-disabled,
-.ui-widget-content .ui-state-disabled,
-.ui-widget-header .ui-state-disabled {
-	opacity: .35;
-	filter: Alpha(Opacity=35);
-	background-image: none
-}
-
-.ui-state-disabled .ui-icon {
-	filter: Alpha(Opacity=35)
-}
-
-.ui-icon {
-	width: 16px;
-	height: 16px
-}
-
-
-.ui-icon-blank {
-	background-position: 16px 16px
-}
-
-
-.ui-corner-all,
-.ui-corner-top,
-.ui-corner-left,
-.ui-corner-tl {
-	border-top-left-radius: 3px
-}
-
-.ui-corner-all,
-.ui-corner-top,
-.ui-corner-right,
-.ui-corner-tr {
-	border-top-right-radius: 3px
-}
-
-.ui-corner-all,
-.ui-corner-bottom,
-.ui-corner-left,
-.ui-corner-bl {
-	border-bottom-left-radius: 3px
-}
-
-.ui-corner-all,
-.ui-corner-bottom,
-.ui-corner-right,
-.ui-corner-br {
-	border-bottom-right-radius: 3px
-}
-
-.ui-widget-overlay {
-	background: #aaa;
-	opacity: .3;
-	filter: Alpha(Opacity=30)
-}
-
-.ui-widget-shadow {
-	-webkit-box-shadow: 0 0 5px #666;
-	box-shadow: 0 0 5px #666
+@layer app {
+	.ui-draggable-handle {
+		-ms-touch-action: none;
+		touch-action: none
+	}
+
+	.ui-helper-hidden {
+		display: none
+	}
+
+	.ui-helper-hidden-accessible {
+		border: 0;
+		clip: rect(0 0 0 0);
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		width: 1px
+	}
+
+	.ui-helper-reset {
+		margin: 0;
+		padding: 0;
+		border: 0;
+		outline: 0;
+		line-height: 1.3;
+		text-decoration: none;
+		font-size: 100%;
+		list-style: none
+	}
+
+	.ui-helper-clearfix:before,
+	.ui-helper-clearfix:after {
+		content: "";
+		display: table;
+		border-collapse: collapse
+	}
+
+	.ui-helper-clearfix:after {
+		clear: both
+	}
+
+	.ui-helper-zfix {
+		width: 100%;
+		height: 100%;
+		top: 0;
+		left: 0;
+		position: absolute;
+		opacity: 0;
+		filter: Alpha(Opacity=0)
+	}
+
+	.ui-front {
+		z-index: 100
+	}
+
+	.ui-state-disabled {
+		cursor: default!important;
+		pointer-events: none
+	}
+
+	.ui-icon {
+		display: inline-block;
+		vertical-align: middle;
+		margin-top: -.25em;
+		position: relative;
+		text-indent: -99999px;
+		overflow: hidden;
+		background-repeat: no-repeat
+	}
+
+	.ui-widget-icon-block {
+		left: 50%;
+		margin-left: -8px;
+		display: block
+	}
+
+	.ui-widget-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%
+	}
+
+	.ui-resizable {
+		position: relative
+	}
+
+	.ui-resizable-handle {
+		position: absolute;
+		font-size: 0.1px;
+		display: block;
+		-ms-touch-action: none;
+		touch-action: none
+	}
+
+	.ui-resizable-disabled .ui-resizable-handle,
+	.ui-resizable-autohide .ui-resizable-handle {
+		display: none
+	}
+
+	.ui-resizable-n {
+		cursor: n-resize;
+		height: 7px;
+		width: 100%;
+		top: -5px;
+		left: 0
+	}
+
+	.ui-resizable-s {
+		cursor: s-resize;
+		height: 7px;
+		width: 100%;
+		bottom: -5px;
+		left: 0
+	}
+
+	.ui-resizable-e {
+		cursor: e-resize;
+		width: 7px;
+		right: -5px;
+		top: 0;
+		height: 100%
+	}
+
+	.ui-resizable-w {
+		cursor: w-resize;
+		width: 7px;
+		left: -5px;
+		top: 0;
+		height: 100%
+	}
+
+	.ui-resizable-se {
+		cursor: se-resize;
+		width: 16px;
+		height: 16px;
+		right: -5px;
+		bottom: -5px
+	}
+
+	.ui-resizable-sw {
+		cursor: sw-resize;
+		width: 16px;
+		height: 16px;
+		left: -5px;
+		bottom: -5px
+	}
+
+	.ui-resizable-nw {
+		cursor: nw-resize;
+		width: 16px;
+		height: 16px;
+		left: -5px;
+		top: -5px
+	}
+
+	.ui-resizable-ne {
+		cursor: ne-resize;
+		width: 16px;
+		height: 16px;
+		right: -5px;
+		top: -5px
+	}
+
+	.ui-selectable {
+		-ms-touch-action: none;
+		touch-action: none
+	}
+
+	.ui-selectable-helper {
+		position: absolute;
+		z-index: 100;
+		border: 1px dotted black
+	}
+
+	.ui-sortable-handle {
+		-ms-touch-action: none;
+		touch-action: none
+	}
+
+	.ui-accordion .ui-accordion-header {
+		display: block;
+		cursor: pointer;
+		position: relative;
+		margin: 2px 0 0 0;
+		padding: .5em .5em .5em .7em;
+		font-size: 100%
+	}
+
+	.ui-accordion .ui-accordion-content {
+		padding: 1em 2.2em;
+		border-top: 0;
+		overflow: auto
+	}
+
+	.ui-autocomplete {
+		position: absolute;
+		top: 0;
+		left: 0;
+		cursor: default
+	}
+
+	.ui-dialog .ui-resizable-se,
+	.ui-dialog .ui-resizable-sw,
+	.ui-dialog .ui-resizable-ne,
+	.ui-dialog .ui-resizable-nw {
+		width: 7px;
+		height: 7px
+	}
+
+	.ui-dialog .ui-resizable-se {
+		right: 0;
+		bottom: 0
+	}
+
+	.ui-dialog .ui-resizable-sw {
+		left: 0;
+		bottom: 0
+	}
+
+	.ui-dialog .ui-resizable-ne {
+		right: 0;
+		top: 0
+	}
+
+	.ui-dialog .ui-resizable-nw {
+		left: 0;
+		top: 0
+	}
+
+	.ui-draggable .ui-dialog-titlebar {
+		cursor: move
+	}
+
+	.ui-progressbar {
+		height: 2em;
+		text-align: left;
+		overflow: hidden
+	}
+
+	.ui-progressbar .ui-progressbar-value {
+		margin: -1px;
+		height: 100%
+	}
+
+	.ui-progressbar .ui-progressbar-overlay {
+		background: url("data:image/gif;base64,R0lGODlhKAAoAIABAAAAAP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJAQABACwAAAAAKAAoAAACkYwNqXrdC52DS06a7MFZI+4FHBCKoDeWKXqymPqGqxvJrXZbMx7Ttc+w9XgU2FB3lOyQRWET2IFGiU9m1frDVpxZZc6bfHwv4c1YXP6k1Vdy292Fb6UkuvFtXpvWSzA+HycXJHUXiGYIiMg2R6W459gnWGfHNdjIqDWVqemH2ekpObkpOlppWUqZiqr6edqqWQAAIfkECQEAAQAsAAAAACgAKAAAApSMgZnGfaqcg1E2uuzDmmHUBR8Qil95hiPKqWn3aqtLsS18y7G1SzNeowWBENtQd+T1JktP05nzPTdJZlR6vUxNWWjV+vUWhWNkWFwxl9VpZRedYcflIOLafaa28XdsH/ynlcc1uPVDZxQIR0K25+cICCmoqCe5mGhZOfeYSUh5yJcJyrkZWWpaR8doJ2o4NYq62lAAACH5BAkBAAEALAAAAAAoACgAAAKVDI4Yy22ZnINRNqosw0Bv7i1gyHUkFj7oSaWlu3ovC8GxNso5fluz3qLVhBVeT/Lz7ZTHyxL5dDalQWPVOsQWtRnuwXaFTj9jVVh8pma9JjZ4zYSj5ZOyma7uuolffh+IR5aW97cHuBUXKGKXlKjn+DiHWMcYJah4N0lYCMlJOXipGRr5qdgoSTrqWSq6WFl2ypoaUAAAIfkECQEAAQAsAAAAACgAKAAAApaEb6HLgd/iO7FNWtcFWe+ufODGjRfoiJ2akShbueb0wtI50zm02pbvwfWEMWBQ1zKGlLIhskiEPm9R6vRXxV4ZzWT2yHOGpWMyorblKlNp8HmHEb/lCXjcW7bmtXP8Xt229OVWR1fod2eWqNfHuMjXCPkIGNileOiImVmCOEmoSfn3yXlJWmoHGhqp6ilYuWYpmTqKUgAAIfkECQEAAQAsAAAAACgAKAAAApiEH6kb58biQ3FNWtMFWW3eNVcojuFGfqnZqSebuS06w5V80/X02pKe8zFwP6EFWOT1lDFk8rGERh1TTNOocQ61Hm4Xm2VexUHpzjymViHrFbiELsefVrn6XKfnt2Q9G/+Xdie499XHd2g4h7ioOGhXGJboGAnXSBnoBwKYyfioubZJ2Hn0RuRZaflZOil56Zp6iioKSXpUAAAh+QQJAQABACwAAAAAKAAoAAACkoQRqRvnxuI7kU1a1UU5bd5tnSeOZXhmn5lWK3qNTWvRdQxP8qvaC+/yaYQzXO7BMvaUEmJRd3TsiMAgswmNYrSgZdYrTX6tSHGZO73ezuAw2uxuQ+BbeZfMxsexY35+/Qe4J1inV0g4x3WHuMhIl2jXOKT2Q+VU5fgoSUI52VfZyfkJGkha6jmY+aaYdirq+lQAACH5BAkBAAEALAAAAAAoACgAAAKWBIKpYe0L3YNKToqswUlvznigd4wiR4KhZrKt9Upqip61i9E3vMvxRdHlbEFiEXfk9YARYxOZZD6VQ2pUunBmtRXo1Lf8hMVVcNl8JafV38aM2/Fu5V16Bn63r6xt97j09+MXSFi4BniGFae3hzbH9+hYBzkpuUh5aZmHuanZOZgIuvbGiNeomCnaxxap2upaCZsq+1kAACH5BAkBAAEALAAAAAAoACgAAAKXjI8By5zf4kOxTVrXNVlv1X0d8IGZGKLnNpYtm8Lr9cqVeuOSvfOW79D9aDHizNhDJidFZhNydEahOaDH6nomtJjp1tutKoNWkvA6JqfRVLHU/QUfau9l2x7G54d1fl995xcIGAdXqMfBNadoYrhH+Mg2KBlpVpbluCiXmMnZ2Sh4GBqJ+ckIOqqJ6LmKSllZmsoq6wpQAAAh+QQJAQABACwAAAAAKAAoAAAClYx/oLvoxuJDkU1a1YUZbJ59nSd2ZXhWqbRa2/gF8Gu2DY3iqs7yrq+xBYEkYvFSM8aSSObE+ZgRl1BHFZNr7pRCavZ5BW2142hY3AN/zWtsmf12p9XxxFl2lpLn1rseztfXZjdIWIf2s5dItwjYKBgo9yg5pHgzJXTEeGlZuenpyPmpGQoKOWkYmSpaSnqKileI2FAAACH5BAkBAAEALAAAAAAoACgAAAKVjB+gu+jG4kORTVrVhRlsnn2dJ3ZleFaptFrb+CXmO9OozeL5VfP99HvAWhpiUdcwkpBH3825AwYdU8xTqlLGhtCosArKMpvfa1mMRae9VvWZfeB2XfPkeLmm18lUcBj+p5dnN8jXZ3YIGEhYuOUn45aoCDkp16hl5IjYJvjWKcnoGQpqyPlpOhr3aElaqrq56Bq7VAAAOw==");
+		height: 100%;
+		filter: alpha(opacity=25);
+		opacity: 0.25
+	}
+
+	.ui-progressbar-indeterminate .ui-progressbar-value {
+		background-image: none
+	}
+
+	.ui-tooltip {
+		padding: 8px;
+		position: absolute;
+		z-index: 9999;
+		max-width: 300px
+	}
+
+	body .ui-tooltip {
+		border-width: 2px
+	}
+
+	.ui-widget {
+		font-family: Arial, Helvetica, sans-serif;
+		font-size: 1em
+	}
+
+	.ui-widget .ui-widget {
+		font-size: 1em
+	}
+
+	.ui-widget input,
+	.ui-widget select,
+	.ui-widget textarea,
+	.ui-widget button {
+		font-family: Arial, Helvetica, sans-serif;
+		font-size: 1em
+	}
+
+	.ui-widget.ui-widget-content {
+		border: 1px solid #c5c5c5
+	}
+
+	.ui-widget-content {
+		border: 1px solid #ddd;
+		background: #fff;
+		color: #333
+	}
+
+	.ui-widget-content a {
+		color: #333
+	}
+
+	.ui-widget-header {
+		border: 1px solid #ddd;
+		background: #e9e9e9;
+		color: #333;
+		font-weight: bold
+	}
+
+	.ui-widget-header a {
+		color: #333
+	}
+
+	.ui-state-default,
+	.ui-widget-content .ui-state-default,
+	.ui-widget-header .ui-state-default,
+	.ui-button,
+	html .ui-button.ui-state-disabled:hover,
+	html .ui-button.ui-state-disabled:active {
+		border: 1px solid #c5c5c5;
+		background: #f6f6f6;
+		font-weight: normal;
+		color: #454545
+	}
+
+	.ui-state-default a,
+	.ui-state-default a:link,
+	.ui-state-default a:visited,
+	a.ui-button,
+	a:link.ui-button,
+	a:visited.ui-button,
+	.ui-button {
+		color: #454545;
+		text-decoration: none
+	}
+
+	.ui-state-hover,
+	.ui-widget-content .ui-state-hover,
+	.ui-widget-header .ui-state-hover,
+	.ui-state-focus,
+	.ui-widget-content .ui-state-focus,
+	.ui-widget-header .ui-state-focus,
+	.ui-button:hover,
+	.ui-button:focus {
+		border: 1px solid #ccc;
+		background: #ededed;
+		font-weight: normal;
+		color: #2b2b2b
+	}
+
+	.ui-state-hover a,
+	.ui-state-hover a:hover,
+	.ui-state-hover a:link,
+	.ui-state-hover a:visited,
+	.ui-state-focus a,
+	.ui-state-focus a:hover,
+	.ui-state-focus a:link,
+	.ui-state-focus a:visited,
+	a.ui-button:hover,
+	a.ui-button:focus {
+		color: #2b2b2b;
+		text-decoration: none
+	}
+
+	.ui-visual-focus {
+		box-shadow: 0 0 3px 1px rgb(94, 158, 214)
+	}
+
+	.ui-state-active,
+	.ui-widget-content .ui-state-active,
+	.ui-widget-header .ui-state-active,
+	a.ui-button:active,
+	.ui-button:active,
+	.ui-button.ui-state-active:hover {
+		border: 1px solid #003eff;
+		background: #007fff;
+		font-weight: normal;
+		color: #fff
+	}
+
+	.ui-icon-background,
+	.ui-state-active .ui-icon-background {
+		border: #003eff;
+		background-color: #fff
+	}
+
+	.ui-state-active a,
+	.ui-state-active a:link,
+	.ui-state-active a:visited {
+		color: #fff;
+		text-decoration: none
+	}
+
+	.ui-state-highlight,
+	.ui-widget-content .ui-state-highlight,
+	.ui-widget-header .ui-state-highlight {
+		border: 1px solid #dad55e;
+		background: #fffa90;
+		color: #777620
+	}
+
+	.ui-state-checked {
+		border: 1px solid #dad55e;
+		background: #fffa90
+	}
+
+	.ui-state-highlight a,
+	.ui-widget-content .ui-state-highlight a,
+	.ui-widget-header .ui-state-highlight a {
+		color: #777620
+	}
+
+	.ui-state-error,
+	.ui-widget-content .ui-state-error,
+	.ui-widget-header .ui-state-error {
+		border: 1px solid #f1a899;
+		background: #fddfdf;
+		color: #5f3f3f
+	}
+
+	.ui-state-error a,
+	.ui-widget-content .ui-state-error a,
+	.ui-widget-header .ui-state-error a {
+		color: #5f3f3f
+	}
+
+	.ui-state-error-text,
+	.ui-widget-content .ui-state-error-text,
+	.ui-widget-header .ui-state-error-text {
+		color: #5f3f3f
+	}
+
+	.ui-priority-primary,
+	.ui-widget-content .ui-priority-primary,
+	.ui-widget-header .ui-priority-primary {
+		font-weight: bold
+	}
+
+	.ui-priority-secondary,
+	.ui-widget-content .ui-priority-secondary,
+	.ui-widget-header .ui-priority-secondary {
+		opacity: .7;
+		filter: Alpha(Opacity=70);
+		font-weight: normal
+	}
+
+	.ui-state-disabled,
+	.ui-widget-content .ui-state-disabled,
+	.ui-widget-header .ui-state-disabled {
+		opacity: .35;
+		filter: Alpha(Opacity=35);
+		background-image: none
+	}
+
+	.ui-state-disabled .ui-icon {
+		filter: Alpha(Opacity=35)
+	}
+
+	.ui-icon {
+		width: 16px;
+		height: 16px
+	}
+
+
+	.ui-icon-blank {
+		background-position: 16px 16px
+	}
+
+
+	.ui-corner-all,
+	.ui-corner-top,
+	.ui-corner-left,
+	.ui-corner-tl {
+		border-top-left-radius: 3px
+	}
+
+	.ui-corner-all,
+	.ui-corner-top,
+	.ui-corner-right,
+	.ui-corner-tr {
+		border-top-right-radius: 3px
+	}
+
+	.ui-corner-all,
+	.ui-corner-bottom,
+	.ui-corner-left,
+	.ui-corner-bl {
+		border-bottom-left-radius: 3px
+	}
+
+	.ui-corner-all,
+	.ui-corner-bottom,
+	.ui-corner-right,
+	.ui-corner-br {
+		border-bottom-right-radius: 3px
+	}
+
+	.ui-widget-overlay {
+		background: #aaa;
+		opacity: .3;
+		filter: Alpha(Opacity=30)
+	}
+
+	.ui-widget-shadow {
+		-webkit-box-shadow: 0 0 5px #666;
+		box-shadow: 0 0 5px #666
+	}
 }

--- a/css/panels.css
+++ b/css/panels.css
@@ -1,4 +1,5 @@
 /*Panel*/
+@layer app {
 	.panel {
 		background-color: var(--color-ui);
 		display: flex;
@@ -2031,3 +2032,4 @@
 	#skin_pose_selector > li:hover .pose_icon {
 		background-color: var(--color-light);
 	}
+}

--- a/css/prism.css
+++ b/css/prism.css
@@ -5,7 +5,8 @@ https://prismjs.com/download.html#themes=prism-okaidia&languages=css+json */
  * Loosely based on Monokai textmate theme by http://www.monokai.nl/
  * @author ocodia
  */
-
+ 
+@layer app {
  .prism-editor-wrapper code{font-family:inherit;line-height:inherit}.prism-editor-wrapper{width:100%;height:100%;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-align:start;-ms-flex-align:start;align-items:flex-start;overflow:auto;-o-tab-size:1.5em;tab-size:1.5em;-moz-tab-size:1.5em}.prism-editor__line-numbers{height:100%;overflow:hidden;-ms-flex-negative:0;flex-shrink:0;padding-top:4px;margin-top:0}.prism-editor__line-number{text-align:right;white-space:nowrap}.prism-editor__code{margin-top:0!important;margin-bottom:0!important;-webkit-box-flex:2;-ms-flex-positive:2;flex-grow:2;min-height:100%;-webkit-box-sizing:border-box;box-sizing:border-box;-o-tab-size:4;tab-size:4;-moz-tab-size:4;outline:none}pre.prism-editor__code:focus{outline:none}
 
 code[class*="language-"],
@@ -125,4 +126,4 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
-
+}

--- a/css/setup.css
+++ b/css/setup.css
@@ -1,5 +1,6 @@
 
 /*INIT*/
+@layer app {
 	* {
 		margin: 0;
 		padding: 0;
@@ -711,3 +712,4 @@
 	.y_scrollable {
 		overflow-y: scroll;
 	}
+}

--- a/css/spectrum.css
+++ b/css/spectrum.css
@@ -5,486 +5,488 @@ Author: Brian Grinstead
 License: MIT
 ***/
 
-.sp-container {
-    position:absolute;
-    top:0;
-    left:0;
-    display:inline-block;
-    *display: inline;
-    *zoom: 1;
-    /* https://github.com/bgrins/spectrum/issues/40 */
-    z-index: 1;
-    overflow: hidden; 
-}
-.sp-container:not(.sp-flat) {
-    z-index: 22;
-}
-.sp-container.sp-flat {
-    position: relative;
-    background: transparent;
-    box-shadow: none;
-    border: none;
-    width: 100%;
-}
-.sp-container.sp-flat {
-    position: relative;
-    background: transparent;
-    box-shadow: none;
-}
-.sp-container.sp-flat .sp-picker-container {
-    width: calc(100% - 4px);
-    padding: 2px;
-    padding-bottom: 0;
-    margin-bottom: -12px;
-}
-.sp-container.sp-flat .sp-button-container {
-    display: none;
-}
-.sp-container.sp-flat .sp-input-container {
-    width: 100%;
-}
+@layer app {
+	.sp-container {
+			position:absolute;
+			top:0;
+			left:0;
+			display:inline-block;
+			*display: inline;
+			*zoom: 1;
+			/* https://github.com/bgrins/spectrum/issues/40 */
+			z-index: 1;
+			overflow: hidden; 
+	}
+	.sp-container:not(.sp-flat) {
+			z-index: 22;
+	}
+	.sp-container.sp-flat {
+			position: relative;
+			background: transparent;
+			box-shadow: none;
+			border: none;
+			width: 100%;
+	}
+	.sp-container.sp-flat {
+			position: relative;
+			background: transparent;
+			box-shadow: none;
+	}
+	.sp-container.sp-flat .sp-picker-container {
+			width: calc(100% - 4px);
+			padding: 2px;
+			padding-bottom: 0;
+			margin-bottom: -12px;
+	}
+	.sp-container.sp-flat .sp-button-container {
+			display: none;
+	}
+	.sp-container.sp-flat .sp-input-container {
+			width: 100%;
+	}
 
-/* Fix for * { box-sizing: border-box; } */
-.sp-container,
-.sp-container * {
-    -webkit-box-sizing: content-box;
-       -moz-box-sizing: content-box;
-            box-sizing: content-box;
-}
+	/* Fix for * { box-sizing: border-box; } */
+	.sp-container,
+	.sp-container * {
+			-webkit-box-sizing: content-box;
+				-moz-box-sizing: content-box;
+							box-sizing: content-box;
+	}
 
-/* http://ansciath.tumblr.com/post/7347495869/css-aspect-ratio */
-.sp-top {
-  position:relative;
-  width: 100%;
-  display:inline-block;
-}
-.sp-top-inner {
-   position:absolute;
-   top:0;
-   left:0;
-   bottom: 4px;
-   right:0;
-}
-.sp-alpha-enabled .sp-top-inner {
-   bottom: 16px;
-}
-.sp-color {
-    position: absolute;
-    top:0;
-    left:0;
-    bottom:0;
-    right: 32px;
-}
-.sp-hue {
-    position: absolute;
-    top:0;
-    right:0;
-    bottom:0;
-    width: 24px; 
-    height: 100%;
-}
+	/* http://ansciath.tumblr.com/post/7347495869/css-aspect-ratio */
+	.sp-top {
+		position:relative;
+		width: 100%;
+		display:inline-block;
+	}
+	.sp-top-inner {
+		position:absolute;
+		top:0;
+		left:0;
+		bottom: 4px;
+		right:0;
+	}
+	.sp-alpha-enabled .sp-top-inner {
+		bottom: 16px;
+	}
+	.sp-color {
+			position: absolute;
+			top:0;
+			left:0;
+			bottom:0;
+			right: 32px;
+	}
+	.sp-hue {
+			position: absolute;
+			top:0;
+			right:0;
+			bottom:0;
+			width: 24px; 
+			height: 100%;
+	}
 
-.sp-clear-enabled .sp-hue {
-    top:30px;
-    height: 77.5%;
-}
+	.sp-clear-enabled .sp-hue {
+			top:30px;
+			height: 77.5%;
+	}
 
-.sp-fill {
-    padding-top: 80%;
-}
-.sp-sat, .sp-val {
-    position: absolute;
-    top:0;
-    left:0;
-    right:0;
-    bottom:0;
-}
+	.sp-fill {
+			padding-top: 80%;
+	}
+	.sp-sat, .sp-val {
+			position: absolute;
+			top:0;
+			left:0;
+			right:0;
+			bottom:0;
+	}
 
-.sp-alpha-enabled .sp-top {
-    margin-bottom: 12px;
-}
-.sp-alpha-enabled .sp-alpha {
-    display: block;
-}
-.sp-alpha-handle {
-    position: absolute;
-    top: 0px;
-    bottom: -4px;
-    left: 50%;
-    cursor: pointer;
-    display: block;
-    height: 30px;
-    width: 12px;
-    margin-top: -6px;
-    background-color: var(--color-ui);
-    border: 1px solid var(--color-border);
-}
-.sp-alpha-inner:hover .sp-alpha-handle {
-    background-color: var(--color-accent);
-}
-.sp-alpha {
-    display: none;
-    position: absolute;
-    bottom: -14px;
-    right: 0;
-    left: 0;
-    height: 22px;
-    margin-top: 16px;
-}
+	.sp-alpha-enabled .sp-top {
+			margin-bottom: 12px;
+	}
+	.sp-alpha-enabled .sp-alpha {
+			display: block;
+	}
+	.sp-alpha-handle {
+			position: absolute;
+			top: 0px;
+			bottom: -4px;
+			left: 50%;
+			cursor: pointer;
+			display: block;
+			height: 30px;
+			width: 12px;
+			margin-top: -6px;
+			background-color: var(--color-ui);
+			border: 1px solid var(--color-border);
+	}
+	.sp-alpha-inner:hover .sp-alpha-handle {
+			background-color: var(--color-accent);
+	}
+	.sp-alpha {
+			display: none;
+			position: absolute;
+			bottom: -14px;
+			right: 0;
+			left: 0;
+			height: 22px;
+			margin-top: 16px;
+	}
 
-.sp-clear {
-    display: none;
-}
+	.sp-clear {
+			display: none;
+	}
 
-.sp-clear.sp-clear-display {
-    background-position: center;
-}
+	.sp-clear.sp-clear-display {
+			background-position: center;
+	}
 
-.sp-clear-enabled .sp-clear {
-    display: block;
-    position:absolute;
-    top:0px;
-    right:0;
-    bottom:0;
-    left:84%;
-    height: 28px;
-}
+	.sp-clear-enabled .sp-clear {
+			display: block;
+			position:absolute;
+			top:0px;
+			right:0;
+			bottom:0;
+			left:84%;
+			height: 28px;
+	}
 
-/* Don't allow text selection */
-.sp-container, .sp-replacer, .sp-preview, .sp-dragger, .sp-slider, .sp-alpha, .sp-clear, .sp-alpha-handle, .sp-container.sp-dragging .sp-input, .sp-container button  {
-    -webkit-user-select:none;
-    -moz-user-select: -moz-none;
-    -o-user-select:none;
-    user-select: none;
-}
+	/* Don't allow text selection */
+	.sp-container, .sp-replacer, .sp-preview, .sp-dragger, .sp-slider, .sp-alpha, .sp-clear, .sp-alpha-handle, .sp-container.sp-dragging .sp-input, .sp-container button  {
+			-webkit-user-select:none;
+			-moz-user-select: -moz-none;
+			-o-user-select:none;
+			user-select: none;
+	}
 
-.sp-container.sp-input-disabled .sp-input-container {
-    display: none;
-}
-.sp-container.sp-buttons-disabled .sp-button-container {
-    display: none;
-}
-.sp-container.sp-palette-buttons-disabled .sp-palette-button-container {
-    display: none;
-}
-.sp-palette-only .sp-picker-container {
-    display: none;
-}
-.sp-palette-disabled .sp-palette-container {
-    display: none;
-}
+	.sp-container.sp-input-disabled .sp-input-container {
+			display: none;
+	}
+	.sp-container.sp-buttons-disabled .sp-button-container {
+			display: none;
+	}
+	.sp-container.sp-palette-buttons-disabled .sp-palette-button-container {
+			display: none;
+	}
+	.sp-palette-only .sp-picker-container {
+			display: none;
+	}
+	.sp-palette-disabled .sp-palette-container {
+			display: none;
+	}
 
-.sp-initial-disabled .sp-initial {
-    display: none;
-}
-
-
-/* Gradients for hue, saturation and value instead of images.  Not pretty... but it works */
-.sp-sat {
-    background-image: -webkit-gradient(linear,  0 0, 100% 0, from(#FFF), to(rgba(204, 154, 129, 0)));
-    background-image: -webkit-linear-gradient(left, #FFF, rgba(204, 154, 129, 0));
-    background-image: -moz-linear-gradient(left, #fff, rgba(204, 154, 129, 0));
-    background-image: -o-linear-gradient(left, #fff, rgba(204, 154, 129, 0));
-    background-image: -ms-linear-gradient(left, #fff, rgba(204, 154, 129, 0));
-    background-image: linear-gradient(to right, #fff, rgba(204, 154, 129, 0));
-    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType = 1, startColorstr=#FFFFFFFF, endColorstr=#00CC9A81)";
-    filter : progid:DXImageTransform.Microsoft.gradient(GradientType = 1, startColorstr='#FFFFFFFF', endColorstr='#00CC9A81');
-}
-.sp-val {
-    background-image: -webkit-gradient(linear, 0 100%, 0 0, from(#000000), to(rgba(204, 154, 129, 0)));
-    background-image: -webkit-linear-gradient(bottom, #000000, rgba(204, 154, 129, 0));
-    background-image: -moz-linear-gradient(bottom, #000, rgba(204, 154, 129, 0));
-    background-image: -o-linear-gradient(bottom, #000, rgba(204, 154, 129, 0));
-    background-image: -ms-linear-gradient(bottom, #000, rgba(204, 154, 129, 0));
-    background-image: linear-gradient(to top, #000, rgba(204, 154, 129, 0));
-    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#00CC9A81, endColorstr=#FF000000)";
-    filter : progid:DXImageTransform.Microsoft.gradient(startColorstr='#00CC9A81', endColorstr='#FF000000');
-}
-
-.sp-hue {
-    background: -moz-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
-    background: -ms-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
-    background: -o-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
-    background: -webkit-gradient(linear, left top, left bottom, from(#ff0000), color-stop(0.17, #ffff00), color-stop(0.33, #00ff00), color-stop(0.5, #00ffff), color-stop(0.67, #0000ff), color-stop(0.83, #ff00ff), to(#ff0000));
-    background: -webkit-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
-    background: linear-gradient(to bottom, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
-}
-
-/* IE filters do not support multiple color stops.
-   Generate 6 divs, line them up, and do two color gradients for each.
-   Yes, really.
- */
-.sp-1 {
-    height:17%;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0000', endColorstr='#ffff00');
-}
-.sp-2 {
-    height:16%;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffff00', endColorstr='#00ff00');
-}
-.sp-3 {
-    height:17%;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ff00', endColorstr='#00ffff');
-}
-.sp-4 {
-    height:17%;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffff', endColorstr='#0000ff');
-}
-.sp-5 {
-    height:16%;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0000ff', endColorstr='#ff00ff');
-}
-.sp-6 {
-    height:17%;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff00ff', endColorstr='#ff0000');
-}
-
-.sp-hidden {
-    display: none !important;
-}
-
-/* Clearfix hack */
-.sp-cf:before, .sp-cf:after { content: ""; display: table; }
-.sp-cf:after { clear: both; }
-.sp-cf { *zoom: 1; }
-
-body.is_touch .sp-fill { padding-top: 64%; }
-
-.sp-dragger {
-   border-radius: 6px;
-   height: 8px;
-   width: 8px;
-   border: 1px solid var(--color-border);
-   background: var(--color-light);
-   cursor: pointer;
-   position:absolute;
-   top:0;
-   left: 0;
-    margin-top: 3px;
-    margin-left: 3px;
-}
-.sp-slider {
-    position: absolute;
-    top:0;
-    cursor:pointer;
-    height: 0;
-    left: -3px;
-    right: -3px;
-    margin-top: -8px;
-    border-color: var(--color-light);
-    border-style: solid;
-    border-width: 8px;
-    border-top-color: transparent;
-    border-bottom-color: transparent;
-    margin-top: -8px;
-    border-radius: 3px;
-}
-
-/*
-Theme authors:
-Here are the basic themeable display options (colors, fonts, global widths).
-See http://bgrins.github.io/spectrum/themes/ for instructions.
-*/
-
-.sp-container {
-    border-radius: 0;
-    background-color: var(--color-ui);
-    box-shadow: 0 0 6px rgba(0, 0, 0, 0.9);
-    padding: 0;
-}
-.sp-container, .sp-container button, .sp-container input, .sp-color, .sp-hue, .sp-clear {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    -ms-box-sizing: border-box;
-    box-sizing: border-box;
-}
-
-/* Input */
-.sp-input-container {
-    float: left;
-    width: 48%;
-    margin-top: -3px;
-}
-.sp-input {
-    height: 30px;
-    width: 100%;
-    padding-left: 4px;
-    background-color: var(--color-back);
-    border: 1px solid var(--color-border);
-    font-family: var(--font-code);
-    font-size: 0.8em;
-}
-.sp-input.sp-validation-error {
-    border: 1px solid red;
-}
-.sp-picker-container , .sp-palette-container {
-    float:left;
-    position: relative;
-    padding: 10px;
-}
-.sp-picker-container {
-    width: 172px;
-    padding-left: 8px;
-}
-
-/* Palettes */
-.sp-palette-container {
-    padding-right: 0;
-}
-
-.sp-palette-only .sp-palette-container {
-    border: 0;
-}
-
-.sp-palette .sp-thumb-el {
-    display: block;
-    position:relative;
-    float:left;
-    width: 24px;
-    height: 15px;
-    margin: 3px;
-    cursor: pointer;
-    border:solid 2px transparent;
-}
-.sp-palette .sp-thumb-el:hover, .sp-palette .sp-thumb-el.sp-thumb-active {
-    border-color: var(--color-accent);
-}
-.sp-thumb-el {
-    position:relative;
-}
-
-/* Initial */
-.sp-initial {
-    float: left;
-    border: solid 1px #333;
-}
-.sp-initial span {
-    width: 30px;
-    height: 25px;
-    border:none;
-    display:block;
-    float:left;
-    margin:0;
-}
-
-.sp-initial .sp-clear-display {
-    background-position: center;
-}
-
-/* Buttons */
-.sp-palette-button-container,
-.sp-button-container {
-    float: right;
-    height: 27px;
-}
-.sp-button-container a:hover {
-    color: var(--color-light);
-}
-
-/* Replacer (the little preview div that shows up instead of the <input>) */
-.sp-replacer {
-    margin:0;
-    overflow:hidden;
-    cursor:pointer;
-    padding: 6px;
-    height: 30px;
-    display:inline-block;
-    *zoom: 1;
-    *display: inline;
-    background: var(--color-button);
-    color: var(--color-text);
-    vertical-align: middle;
-    outline: none;
-}
-.sp-replacer:hover, .sp-replacer.sp-active {
-    color: var(--color-light);
-}
-.sp-replacer.sp-disabled {
-    cursor:default;
-    border-color: silver;
-    color: silver;
-}
-.sp-dd {
-    padding: 2px 0;
-    height: 16px;
-    line-height: 16px;
-    float:left;
-    font-size:10px;
-    pointer-events: none;
-}
-.sp-preview {
-    position:relative;
-    width:25px;
-    height: 20px;
-    margin-right: 5px;
-    float:left;
-    z-index: 0;
-    pointer-events: none;
-}
-
-.sp-palette {
-    width: 40px;
-    max-height: 220px;
-    overflow-y: scroll;
-}
-.sp-palette .sp-thumb-el {
-    width: 26px;
-    height: 20px;
-    margin: 1px;
-    border: 2px solid var(--color-border);
-}
+	.sp-initial-disabled .sp-initial {
+			display: none;
+	}
 
 
-.sp-reset {
-    font-size: 11px;
-    margin:0;
-    padding:2px;
-    margin-right: 5px;
-    vertical-align: middle;
-    text-decoration:none;
-}
-.sp-cancel {
-    font-size: 11px;
-    margin:0;
-    padding:2px;
-    margin-right: 5px;
-    vertical-align: middle;
-    text-decoration:none;
-}
-.sp-choose {
-    vertical-align: middle;
-}
+	/* Gradients for hue, saturation and value instead of images.  Not pretty... but it works */
+	.sp-sat {
+			background-image: -webkit-gradient(linear,  0 0, 100% 0, from(#FFF), to(rgba(204, 154, 129, 0)));
+			background-image: -webkit-linear-gradient(left, #FFF, rgba(204, 154, 129, 0));
+			background-image: -moz-linear-gradient(left, #fff, rgba(204, 154, 129, 0));
+			background-image: -o-linear-gradient(left, #fff, rgba(204, 154, 129, 0));
+			background-image: -ms-linear-gradient(left, #fff, rgba(204, 154, 129, 0));
+			background-image: linear-gradient(to right, #fff, rgba(204, 154, 129, 0));
+			-ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType = 1, startColorstr=#FFFFFFFF, endColorstr=#00CC9A81)";
+			filter : progid:DXImageTransform.Microsoft.gradient(GradientType = 1, startColorstr='#FFFFFFFF', endColorstr='#00CC9A81');
+	}
+	.sp-val {
+			background-image: -webkit-gradient(linear, 0 100%, 0 0, from(#000000), to(rgba(204, 154, 129, 0)));
+			background-image: -webkit-linear-gradient(bottom, #000000, rgba(204, 154, 129, 0));
+			background-image: -moz-linear-gradient(bottom, #000, rgba(204, 154, 129, 0));
+			background-image: -o-linear-gradient(bottom, #000, rgba(204, 154, 129, 0));
+			background-image: -ms-linear-gradient(bottom, #000, rgba(204, 154, 129, 0));
+			background-image: linear-gradient(to top, #000, rgba(204, 154, 129, 0));
+			-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#00CC9A81, endColorstr=#FF000000)";
+			filter : progid:DXImageTransform.Microsoft.gradient(startColorstr='#00CC9A81', endColorstr='#FF000000');
+	}
+
+	.sp-hue {
+			background: -moz-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
+			background: -ms-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
+			background: -o-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
+			background: -webkit-gradient(linear, left top, left bottom, from(#ff0000), color-stop(0.17, #ffff00), color-stop(0.33, #00ff00), color-stop(0.5, #00ffff), color-stop(0.67, #0000ff), color-stop(0.83, #ff00ff), to(#ff0000));
+			background: -webkit-linear-gradient(top, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
+			background: linear-gradient(to bottom, #ff0000 0%, #ffff00 17%, #00ff00 33%, #00ffff 50%, #0000ff 67%, #ff00ff 83%, #ff0000 100%);
+	}
+
+	/* IE filters do not support multiple color stops.
+		Generate 6 divs, line them up, and do two color gradients for each.
+		Yes, really.
+	*/
+	.sp-1 {
+			height:17%;
+			filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0000', endColorstr='#ffff00');
+	}
+	.sp-2 {
+			height:16%;
+			filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffff00', endColorstr='#00ff00');
+	}
+	.sp-3 {
+			height:17%;
+			filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ff00', endColorstr='#00ffff');
+	}
+	.sp-4 {
+			height:17%;
+			filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffff', endColorstr='#0000ff');
+	}
+	.sp-5 {
+			height:16%;
+			filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0000ff', endColorstr='#ff00ff');
+	}
+	.sp-6 {
+			height:17%;
+			filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff00ff', endColorstr='#ff0000');
+	}
+
+	.sp-hidden {
+			display: none !important;
+	}
+
+	/* Clearfix hack */
+	.sp-cf:before, .sp-cf:after { content: ""; display: table; }
+	.sp-cf:after { clear: both; }
+	.sp-cf { *zoom: 1; }
+
+	body.is_touch .sp-fill { padding-top: 64%; }
+
+	.sp-dragger {
+		border-radius: 6px;
+		height: 8px;
+		width: 8px;
+		border: 1px solid var(--color-border);
+		background: var(--color-light);
+		cursor: pointer;
+		position:absolute;
+		top:0;
+		left: 0;
+			margin-top: 3px;
+			margin-left: 3px;
+	}
+	.sp-slider {
+			position: absolute;
+			top:0;
+			cursor:pointer;
+			height: 0;
+			left: -3px;
+			right: -3px;
+			margin-top: -8px;
+			border-color: var(--color-light);
+			border-style: solid;
+			border-width: 8px;
+			border-top-color: transparent;
+			border-bottom-color: transparent;
+			margin-top: -8px;
+			border-radius: 3px;
+	}
+
+	/*
+	Theme authors:
+	Here are the basic themeable display options (colors, fonts, global widths).
+	See http://bgrins.github.io/spectrum/themes/ for instructions.
+	*/
+
+	.sp-container {
+			border-radius: 0;
+			background-color: var(--color-ui);
+			box-shadow: 0 0 6px rgba(0, 0, 0, 0.9);
+			padding: 0;
+	}
+	.sp-container, .sp-container button, .sp-container input, .sp-color, .sp-hue, .sp-clear {
+			-webkit-box-sizing: border-box;
+			-moz-box-sizing: border-box;
+			-ms-box-sizing: border-box;
+			box-sizing: border-box;
+	}
+
+	/* Input */
+	.sp-input-container {
+			float: left;
+			width: 48%;
+			margin-top: -3px;
+	}
+	.sp-input {
+			height: 30px;
+			width: 100%;
+			padding-left: 4px;
+			background-color: var(--color-back);
+			border: 1px solid var(--color-border);
+			font-family: var(--font-code);
+			font-size: 0.8em;
+	}
+	.sp-input.sp-validation-error {
+			border: 1px solid red;
+	}
+	.sp-picker-container , .sp-palette-container {
+			float:left;
+			position: relative;
+			padding: 10px;
+	}
+	.sp-picker-container {
+			width: 172px;
+			padding-left: 8px;
+	}
+
+	/* Palettes */
+	.sp-palette-container {
+			padding-right: 0;
+	}
+
+	.sp-palette-only .sp-palette-container {
+			border: 0;
+	}
+
+	.sp-palette .sp-thumb-el {
+			display: block;
+			position:relative;
+			float:left;
+			width: 24px;
+			height: 15px;
+			margin: 3px;
+			cursor: pointer;
+			border:solid 2px transparent;
+	}
+	.sp-palette .sp-thumb-el:hover, .sp-palette .sp-thumb-el.sp-thumb-active {
+			border-color: var(--color-accent);
+	}
+	.sp-thumb-el {
+			position:relative;
+	}
+
+	/* Initial */
+	.sp-initial {
+			float: left;
+			border: solid 1px #333;
+	}
+	.sp-initial span {
+			width: 30px;
+			height: 25px;
+			border:none;
+			display:block;
+			float:left;
+			margin:0;
+	}
+
+	.sp-initial .sp-clear-display {
+			background-position: center;
+	}
+
+	/* Buttons */
+	.sp-palette-button-container,
+	.sp-button-container {
+			float: right;
+			height: 27px;
+	}
+	.sp-button-container a:hover {
+			color: var(--color-light);
+	}
+
+	/* Replacer (the little preview div that shows up instead of the <input>) */
+	.sp-replacer {
+			margin:0;
+			overflow:hidden;
+			cursor:pointer;
+			padding: 6px;
+			height: 30px;
+			display:inline-block;
+			*zoom: 1;
+			*display: inline;
+			background: var(--color-button);
+			color: var(--color-text);
+			vertical-align: middle;
+			outline: none;
+	}
+	.sp-replacer:hover, .sp-replacer.sp-active {
+			color: var(--color-light);
+	}
+	.sp-replacer.sp-disabled {
+			cursor:default;
+			border-color: silver;
+			color: silver;
+	}
+	.sp-dd {
+			padding: 2px 0;
+			height: 16px;
+			line-height: 16px;
+			float:left;
+			font-size:10px;
+			pointer-events: none;
+	}
+	.sp-preview {
+			position:relative;
+			width:25px;
+			height: 20px;
+			margin-right: 5px;
+			float:left;
+			z-index: 0;
+			pointer-events: none;
+	}
+
+	.sp-palette {
+			width: 40px;
+			max-height: 220px;
+			overflow-y: scroll;
+	}
+	.sp-palette .sp-thumb-el {
+			width: 26px;
+			height: 20px;
+			margin: 1px;
+			border: 2px solid var(--color-border);
+	}
+
+
+	.sp-reset {
+			font-size: 11px;
+			margin:0;
+			padding:2px;
+			margin-right: 5px;
+			vertical-align: middle;
+			text-decoration:none;
+	}
+	.sp-cancel {
+			font-size: 11px;
+			margin:0;
+			padding:2px;
+			margin-right: 5px;
+			vertical-align: middle;
+			text-decoration:none;
+	}
+	.sp-choose {
+			vertical-align: middle;
+	}
 
 
 
-.sp-palette span:hover, .sp-palette span.sp-thumb-active {
-    border-color: #000;
-}
+	.sp-palette span:hover, .sp-palette span.sp-thumb-active {
+			border-color: #000;
+	}
 
-.sp-preview, .sp-alpha, .sp-thumb-el {
-    position:relative;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAIAAADZF8uwAAAAGUlEQVQYV2M4gwH+YwCGIasIUwhT25BVBADtzYNYrHvv4gAAAABJRU5ErkJggg==);
-}
-.sp-preview-inner, .sp-alpha-inner, .sp-thumb-inner {
-    display:block;
-    position:absolute;
-    top:0;left:0;bottom:0;right:0;
-}
+	.sp-preview, .sp-alpha, .sp-thumb-el {
+			position:relative;
+			background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAIAAADZF8uwAAAAGUlEQVQYV2M4gwH+YwCGIasIUwhT25BVBADtzYNYrHvv4gAAAABJRU5ErkJggg==);
+	}
+	.sp-preview-inner, .sp-alpha-inner, .sp-thumb-inner {
+			display:block;
+			position:absolute;
+			top:0;left:0;bottom:0;right:0;
+	}
 
-.sp-palette .sp-thumb-inner {
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-}
+	.sp-palette .sp-thumb-inner {
+			background-position: 50% 50%;
+			background-repeat: no-repeat;
+	}
 
-.sp-palette .sp-thumb-light.sp-thumb-active .sp-thumb-inner {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAIVJREFUeNpiYBhsgJFMffxAXABlN5JruT4Q3wfi/0DsT64h8UD8HmpIPCWG/KemIfOJCUB+Aoacx6EGBZyHBqI+WsDCwuQ9mhxeg2A210Ntfo8klk9sOMijaURm7yc1UP2RNCMbKE9ODK1HM6iegYLkfx8pligC9lCD7KmRof0ZhjQACDAAceovrtpVBRkAAAAASUVORK5CYII=);
-}
+	.sp-palette .sp-thumb-light.sp-thumb-active .sp-thumb-inner {
+			background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAIVJREFUeNpiYBhsgJFMffxAXABlN5JruT4Q3wfi/0DsT64h8UD8HmpIPCWG/KemIfOJCUB+Aoacx6EGBZyHBqI+WsDCwuQ9mhxeg2A210Ntfo8klk9sOMijaURm7yc1UP2RNCMbKE9ODK1HM6iegYLkfx8pligC9lCD7KmRof0ZhjQACDAAceovrtpVBRkAAAAASUVORK5CYII=);
+	}
 
-.sp-palette .sp-thumb-dark.sp-thumb-active .sp-thumb-inner {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAMdJREFUOE+tkgsNwzAMRMugEAahEAahEAZhEAqlEAZhEAohEAYh81X2dIm8fKpEspLGvudPOsUYpxE2BIJCroJmEW9qJ+MKaBFhEMNabSy9oIcIPwrB+afvAUFoK4H0tMaQ3XtlrggDhOVVMuT4E5MMG0FBbCEYzjYT7OxLEvIHQLY2zWwQ3D+9luyOQTfKDiFD3iUIfPk8VqrKjgAiSfGFPecrg6HN6m/iBcwiDAo7WiBeawa+Kwh7tZoSCGLMqwlSAzVDhoK+6vH4G0P5wdkAAAAASUVORK5CYII=);
-}
+	.sp-palette .sp-thumb-dark.sp-thumb-active .sp-thumb-inner {
+			background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAMdJREFUOE+tkgsNwzAMRMugEAahEAahEAZhEAqlEAZhEAohEAYh81X2dIm8fKpEspLGvudPOsUYpxE2BIJCroJmEW9qJ+MKaBFhEMNabSy9oIcIPwrB+afvAUFoK4H0tMaQ3XtlrggDhOVVMuT4E5MMG0FBbCEYzjYT7OxLEvIHQLY2zWwQ3D+9luyOQTfKDiFD3iUIfPk8VqrKjgAiSfGFPecrg6HN6m/iBcwiDAo7WiBeawa+Kwh7tZoSCGLMqwlSAzVDhoK+6vH4G0P5wdkAAAAASUVORK5CYII=);
+	}
 
-.sp-clear-display {
-    background-repeat:no-repeat;
-    background-position: center;
+	.sp-clear-display {
+			background-repeat:no-repeat;
+			background-position: center;
+	}
 }

--- a/css/start_screen.css
+++ b/css/start_screen.css
@@ -1,4 +1,5 @@
 /*Start Screen*/
+@layer app {
 	#mode_screen_start {
 		flex-grow: 1;
 	}
@@ -531,3 +532,4 @@
 	.amend_edit_close_button:hover {
 		color: var(--color-light);
 	}
+}

--- a/css/w3.css
+++ b/css/w3.css
@@ -1,4 +1,5 @@
 /* W3.CSS 4.04 Apr 2017 by Jan Egil and Borge Refsnes */
+@layer app {
 html{box-sizing:border-box}*,*:before,*:after{box-sizing:inherit}
 /* Extract from normalize.css by Nicolas Gallagher and Jonathan Neal git.io/normalize */
 html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}
@@ -29,3 +30,4 @@ html,body{font-family:Verdana,sans-serif;font-size:15px;line-height:1.5}html{ove
 h1{font-size:36px}h2{font-size:30px}h3{font-size:24px}h4{font-size:20px}h5{font-size:18px}h6{font-size:16px}.w3-serif{font-family:serif}
 h1,h2,h3,h4,h5,h6{font-family:"Segoe UI",Arial,sans-serif;font-weight:400;margin:10px 0}.w3-wide{letter-spacing:4px}
 hr{border:0;border-top:1px solid #eee;margin:20px 0}
+}

--- a/css/window.css
+++ b/css/window.css
@@ -1,5 +1,6 @@
 
 /*Layout*/
+@layer app {
 	#page_wrapper {
 		height: calc(100% - 26px);
 		width: 100%;
@@ -971,3 +972,4 @@
 	.amend_edit_close_button:hover {
 		color: var(--color-light);
 	}
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="theme-color" content="#181a1f">
 	<meta name="robots" content="noindex">
+	<style type="text/css">@layer app, custom;</style>
 	<link rel="manifest" href="manifest.webmanifest">
 	<link rel="shortcut icon" href="favicon.png" type="image/x-icon" />
 	<link rel="apple-touch-icon" href="icon_full.png">

--- a/js/interface/themes.js
+++ b/js/interface/themes.js
@@ -396,7 +396,7 @@ const CustomTheme = {
 		document.body.style.setProperty('--font-custom-headline', CustomTheme.data.headline_font);
 		document.body.style.setProperty('--font-custom-code', CustomTheme.data.code_font);
 		document.body.classList.toggle('theme_borders', !!CustomTheme.data.borders);
-		$('style#theme_css').text(CustomTheme.data.css);
+		$('style#theme_css').text(`@layer custom {${CustomTheme.data.css}}`);
 		CustomTheme.updateColors();
 	},
 	loadTheme(theme) {


### PR DESCRIPTION
This pull request wraps non-inline styles in an `app` layer. The `app` layer acts as a foundation on which a `custom` layer acts. All custom CSS configured in the theme editor is wrapped in the latter layer.

This change should allow for more convenient styling upfront. In general, highly customized CSS won’t require `!important` every other property declaration.