### PR TITLE
Fix: Menu won't close after deselecting it

### DIFF
--- a/js/interface/menu_bar.js
+++ b/js/interface/menu_bar.js
@@ -15,9 +15,7 @@ class BarMenu extends Menu {
 		this.label = Interface.createElement('li', {class: 'menu_bar_point'}, this.name);
 		this.label.addEventListener('click', (event) => {
 			if (open_menu === scope) {
-				if (event instanceof PointerEvent == false) {
-					scope.hide()
-				}
+				scope.hide()
 			} else {
 				scope.open()
 			}


### PR DESCRIPTION
This PR fixes the behaviour when clicking on an selected menu bar item (e.g. File). Currently nothing happens when you click the item, which seems to be unintentionally, because there already is code in place to hide the menu, after clicking on it. Sadly the code is not working due to an if statement which won't become true. I've simply removed it (not sure if it is important, then simply close this PR, but maybe there is another way to fix this).
Tested on web (mobileand desktop) and desktop.