### PR TITLE
removed commented out code in undo.js

### DIFF
--- a/js/undo.js
+++ b/js/undo.js
@@ -4,12 +4,6 @@ class UndoSystem {
 		this.history = [];
 	}
 	startChange(amended) {
-		/*if (this.current_save && Painter.painting) {
-			throw 'Canceled edit: Cannot perform edits while painting'
-		}*/
-		/*if (this.current_save && Transformer.dragging) {
-			throw 'Canceled edit: Cannot perform other edits while transforming elements'
-		}*/
 		if (!amended && this.amend_edit_menu) {
 			this.closeAmendEditMenu();
 		}


### PR DESCRIPTION
There's a section of code in undo.js that has commented out code that is not being used. For code cleanliness' sake, let's remove it
