### PR TITLE
Remove trailing space from map_Kd property

### DIFF
--- a/js/io/formats/obj.js
+++ b/js/io/formats/obj.js
@@ -376,7 +376,7 @@ var codec = new Codec('obj', {
 			if (materials.hasOwnProperty(key) && materials[key]) {
 				var tex = materials[key];
 				mtlOutput += 'newmtl m_' +key+ '\n'
-				mtlOutput += `map_Kd ${tex.name} \n`;
+				mtlOutput += `map_Kd ${tex.name}\n`;
 			}
 		}
 		mtlOutput += 'newmtl none'


### PR DESCRIPTION
There is a trailing space in the map_Kd property of an mtl file that prevents some software from reading textures correctly.
