### PR TITLE
Fix leftover faces after vertex merge

### DIFF
--- a/js/modeling/mesh_editing.js
+++ b/js/modeling/mesh_editing.js
@@ -1761,6 +1761,16 @@ BARS.defineActions(function() {
 				}
 			}
 		})
+		// Clean leftover faces
+		Mesh.selected.forEach(mesh => {
+			for (let fkey in mesh.faces) {
+				face = mesh.faces[fkey];
+				if(face.vertices.length <= 2){
+					delete mesh.faces[fkey];
+				}
+			}
+		});
+		// ---
 		Undo.finishEdit('Merge vertices')
 		Canvas.updateView({elements: Mesh.selected, element_aspects: {geometry: true, uv: true, faces: true}, selection: true})
 		if (by_distance) {


### PR DESCRIPTION
As per title. The bug happens everytime you make a face "disappear" through collapsing two-by-two the vertices sorrounding it: check the video below. Ignore the "mirroring" activation: I was looking for another bug when I found this!

https://github.com/JannisX11/blockbench/assets/9095842/e95c0531-59c1-4855-9a01-d86a0f2f3321


