### PR TITLE
WIP: Raycasting for selectability of foreground objects only

### DIFF
--- a/js/outliner/mesh.js
+++ b/js/outliner/mesh.js
@@ -23,6 +23,20 @@ class MeshFace extends Face {
 		}
 		return this;
 	}
+	getCenter(global){
+		let center = [0, 0, 0];
+		let len = 0;
+		for (let vkey in this.vertices) {
+			center.V3_add(this.mesh.vertices[vkey]);
+			len++;
+		}
+		center.V3_divide(len);
+		if (global) {
+			return this.mesh.localToWorld(Reusable.vec1.set(...center)).toArray();
+		} else {
+			return center;
+		}
+	}
 	getNormal(normalize) {
 		let vertices = this.getSortedVertices();
 		if (vertices.length < 3) return [0, 0, 0];

--- a/js/preview/preview.js
+++ b/js/preview/preview.js
@@ -1355,7 +1355,7 @@ class Preview {
 									}
 								}
 								if (selection_mode == 'object') {
-									if (face_intersects && !isForeground(element, element)) {
+									if (face_intersects && isForeground(element, element)) {
 										isSelected = true;
 										break;
 									}


### PR DESCRIPTION
This is meant as an enhancement of #2028, as it's mostly useful for batch selection of vertices and faces; but because that is a fix and this is a feature is a proposal, here we are.

If the wireframe mode is enabled, everything becomes selectable.

The PR also adds a `getCenter(global)` function to the `MeshFace` class.

Check the video below (notice that #2028 is also in use)


https://github.com/JannisX11/blockbench/assets/9095842/9ee3a8e9-8e4d-44a8-8570-3e2b10044f4a

