### PR TITLE
Add scrolling support to NumSlider

### DIFF
--- a/js/boot_loader.js
+++ b/js/boot_loader.js
@@ -22,6 +22,8 @@ if (isApp === false) {
 		Blockbench.browser = 'opera'
 	} else if (/constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && safari.pushNotification))) {
 		Blockbench.browser = 'safari'
+	} else if (typeof InstallTrigger === 'undefined' && !window.chrome && navigator.userAgent.includes('WebKit')) {
+		Blockbench.browser = 'webkit'
 	} else if (!!document.documentMode) {
 		Blockbench.browser = 'internet_explorer'
 	} else if (!!window.chrome && window.navigator.userAgent.toLowerCase().includes('edg')) {

--- a/js/interface/actions.js
+++ b/js/interface/actions.js
@@ -578,6 +578,10 @@ class NumSlider extends Widget {
 		this.type = 'numslider'
 		this.icon = 'code'
 		this.value = 0;
+		this.valueRaw = 0;
+		this.lastDelta = 0;
+		// Whether the device is detected to be a touchpad
+		this.touchpad = false;
 		this.width = 69;
 		this.sensitivity = data.sensitivity || 30;
 		this.invert_scroll_direction = data.invert_scroll_direction == true;
@@ -830,6 +834,57 @@ class NumSlider extends Widget {
 		})
 		.on('mouseleave', function() {
 			scope.jq_outer.find('.nslide_arrow').remove()
+
+			// Self clean-up
+			scope.valueRaw = 0
+			scope.lastDelta = 0;
+			scope.touchpad = false;
+		})
+		.on('wheel', event => {
+			// Prevents scrolling, allowing for continuous adjustment
+			event.preventDefault();
+			// We handled it from here.
+			event.stopPropagation();
+
+			const deltaXMul = Pressing.shift && ['safari', 'webkit'].indexOf(Blockbench.browser) >= 0 ? -1 : 1;
+
+			// TODO: Add a slider for this. Note: The scale is backwards and naturally logarithmic 
+			// TODO: Negative sensitivity for reversed scroll direction
+			let sensitivity = 1/64 * (this.invert_scroll_direction ? -1 : 1);
+
+			// TODO: Find a spot for this to live in.
+			function accel(velocity) {
+				velocity *= sensitivity;
+				return Math.pow(velocity, 2) * Math.sign(velocity);
+			};
+
+			let deltaX = +accel(event.originalEvent.deltaX) * deltaXMul;
+			let deltaY = -accel(event.originalEvent.deltaY)
+			let delta = deltaX + deltaY;
+
+			// Only touchpads and certain mice can scroll on both axises at the same time.
+			if (deltaX && deltaY) {
+				this.touchpad = true;
+			} else if (!this.touchpad && this.lastDelta) {
+				let lastDeltaAbs = Math.abs(this.lastDelta);
+				let deltaAbs = Math.abs(delta);
+
+				// Firefox's scrolling is not consistent between up & down.
+				// This is to attempt to tell touchpad and mousewheel apart.
+
+				let firefox = Math.sign(this.lastDelta) != Math.sign(delta) &&
+				deltaAbs > accel(32) && Math.abs(1 - (lastDeltaAbs / deltaAbs)) < 0.10;
+
+				this.touchpad = lastDeltaAbs != deltaAbs && !firefox;
+			}
+
+			this.lastDelta = delta;
+			
+			if (!this.touchpad) {
+				delta = Math.sign(delta);
+			}
+
+			this.updateValue(this.getInterval(event) * delta);
 		})
 	}
 	startInput(e) {
@@ -864,6 +919,9 @@ class NumSlider extends Widget {
 
 		if (!difference) return;
 
+		this.updateValue(difference);
+	}
+	updateValue(difference) {
 		this.change(n => n + difference);
 		this.update();
 		Blockbench.setStatusBarText(trimFloatNumber(this.value - this.last_value));
@@ -988,11 +1046,12 @@ class NumSlider extends Widget {
 	}
 	change(modify) {
 		//Solo sliders only, gets overwritten for most sliders
-		var num = modify(this.get());
+		var num = modify(this.valueRaw || this.get());
 		if (this.settings && typeof this.settings.min === 'number' && this.settings.limit !== false) {
 			num = limitNumber(num, this.settings.min, this.settings.max)
 		}
-		this.value = num;
+		this.valueRaw = num;
+		this.value = num |= 0;
 		if (this.tool_setting) {
 			Toolbox.selected.tool_settings[this.tool_setting] = num;
 		}


### PR DESCRIPTION
This PR aims to add scrolling support to NumSlider.

I am only opening this as a draft for now for some input as this isn't complete. 

- [x] Supports Chromium, Firefox, Epiphany
  - Note, some specific hackery was added for Epiphany.
    Someone with a MacOS machine would need to validate the following for Safari:
      - [ ] Shift + scrolling up correctly follows normally scrolling up, and vice-versa.
  - Some hackery was added for Firefox to tell it apart from a touchpad, as its deltaY isn't consistent between scrolling up & down.
- [x] Has specific touchpad support
  - [ ] Has a way to adjust sensitivity
  - [x] This includes detecting one to allow for fine adjustments with the scroll gesture.
- [ ] Has a way to reverse scrolling direction
  - This is necessary for natural scrolling. Safari on MacOS has a way to detect this, however no other browser and OS combination can. The best option is to give a way to flip the direction for this.

It is self-resetting to allow a device switch without feeling horrendous, unless you happen to switch to a mouse without leaving the slider.

I shall note that it does make a change to the backing data structure to coerce to an integer via `|0`, which I realise may break the modeller (although surprisingly doesn't?) and plugins expecting to allow non-integer input.

This does also introduce a check for bare WebKit specifically for Epiphany, as it is just detected as bare Electron otherwise.