### PR TITLE
add window-controls-overlay API capability

### DIFF
--- a/css/window.css
+++ b/css/window.css
@@ -295,6 +295,7 @@
 		display: flex;
 		white-space: nowrap;
 		height: 26px;
+		width: env(titlebar-area-x, 100%);
 	}
 	header > * {
 		display: inline-block;

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -24,6 +24,6 @@
 	"background_color": "#21252b",
 	"theme_color": "#3e90ff",
 	"display": "standalone",
-	"display_override": ["tabbed", "minimal-ui"],
+	"display_override": ["window-controls-overlay", "standalone"],
 	"orientation": "any"
 }


### PR DESCRIPTION
Before creating a pull request, please make sure that you have read and understood the [Contribution section](https://github.com/JannisX11/blockbench#contribution) in the README file.
this pull request changes the manifest.json's "display_override" field from "tabbed" to "window-controls-overlay", and adds the 
"width: env(titlebar-area-x, 100%);" CSS property to the "header" element so that the menu bar and tabs do not overlap with the window controls.