### PR TITLE
Fix textures `relative_path` being incorrectly relative to a non-dir

### DIFF
--- a/js/io/formats/bbmodel.js
+++ b/js/io/formats/bbmodel.js
@@ -169,7 +169,9 @@ var codec = new Codec('project', {
 		Texture.all.forEach(tex => {
 			var t = tex.getSaveCopy();
 			if (isApp && Project.save_path && tex.path && PathModule.isAbsolute(tex.path)) {
-				let relative = PathModule.relative(Project.save_path, tex.path);
+				// Relative paths are only valid for directories, but save_path
+				// is a path to a regular file, so dirname is necessary here
+				let relative = PathModule.relative(PathModule.dirname(Project.save_path), tex.path);
 				t.relative_path = relative.replace(/\\/g, '/');
 			}
 			if (options.bitmaps != false && (Settings.get('embed_textures') || options.backup || options.bitmaps == true)) {

--- a/js/io/formats/bbmodel.js
+++ b/js/io/formats/bbmodel.js
@@ -304,7 +304,7 @@ var codec = new Codec('project', {
 			model.textures.forEach(tex => {
 				var tex_copy = new Texture(tex, tex.uuid).add(false);
 				if (isApp && tex.relative_path && Project.save_path) {
-					let resolved_path = PathModule.resolve(Project.save_path, tex.relative_path);
+					let resolved_path = PathModule.resolve(PathModule.dirname(Project.save_path), tex.relative_path);
 					if (fs.existsSync(resolved_path)) {
 						tex_copy.fromPath(resolved_path)
 						return;
@@ -501,7 +501,7 @@ var codec = new Codec('project', {
 				return tex_copy;
 			}
 			if (isApp && tex.relative_path && Project.save_path) {
-				let resolved_path = PathModule.resolve(Project.save_path, tex.relative_path);
+				let resolved_path = PathModule.resolve(PathModule.dirname(Project.save_path), tex.relative_path);
 				if (fs.existsSync(resolved_path)) {
 					tex_copy.fromPath(resolved_path)
 					return tex_copy;


### PR DESCRIPTION
Blockbench may store the relative paths to model textures in its native .bbmodel project format when used as a standalone application. However, this path is relative to the project file instead of the project file directory, which generates invalid relative paths, because such paths are only meant to be relative to directories and not files, as shown in the following figure:

> ![Node REPL showing invalid relative paths](https://github.com/JannisX11/blockbench/assets/7822554/27a7197d-f94b-4010-b0b3-9c2547aac51d)
> The first parameter passed to `path.relative` in the image above represents a possible value of `Project.save_path`, while the second is an absolute texture path. The expected output would be `texture.png` or `./texture.png`, not `../texture.png`.

Fix this problem by calling `dirname` on the project save path that's used to relativize texture paths. Even though this quirk is not documented anywhere and thus I would expect it to be unnoticed by most people, it is nevertheless a technically breaking change, so please let me know if you wish to bump the format version because of this. The relative paths generated after this change have been tested to work well across platforms.