### PR TITLE
add arm64 and armv7l arches to linux CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,11 +79,32 @@
 			"target": "nsis"
 		},
 		"linux": {
-			"artifactName": "${productName}_${version}.${ext}",
+			"artifactName": "${productName}_${arch}_${version}.${ext}",
 			"target": [
-				"deb",
-				"rpm",
-				"appImage"
+				{
+					"target": "deb",
+					"arch": [
+						"x64",
+						"arm64",
+						"armv7l"
+					]
+				},
+				{
+					"target": "rpm",
+					"arch": [
+						"x64",
+						"arm64",
+						"armv7l"
+					]
+				},
+				{
+					"target": "appImage",
+					"arch": [
+						"x64",
+						"arm64",
+						"armv7l"
+					]
+				}
 			],
 			"category": "3DGraphics",
 			"icon": "build/icon.icns"


### PR DESCRIPTION
Known issues:
3rd party library is 4+ years unmaintained and does not have ARM64 or ARMhf scrot native binaries on linux https://www.npmjs.com/package/electron-color-picker

electron-color-picker should be moved away from anyway as it is not wayland compatible which is the current default window system on linux desktops in 2024