### PR TITLE
Fix Smart Save dialog potentially using the wrong codec

### DIFF
--- a/js/io/io.js
+++ b/js/io/io.js
@@ -718,7 +718,7 @@ BARS.defineActions(function() {
 									export_codec.export();
 	
 								} else if (codec) {
-									Codecs[codec].export();
+									export_codec.export();
 								}
 								if (checkboxes.dont_show_again) {
 									settings.dialog_save_codec.set(false);


### PR DESCRIPTION
`Codecs[codec]` in the Smart Save dialog callback may not point to the same codec as the `export_codec` variable for custom formats that reuse the codecs of other formats, but proxy them with the JS `Proxy` class to implement the decorator pattern. To support this use case and increase the consistency of the code, which uses `export_codec` in the nearby lines, let's use that instead.