### PR TITLE
Added tool and gizmo for stretching

### DIFF
--- a/js/interface/actions.js
+++ b/js/interface/actions.js
@@ -1851,6 +1851,7 @@ const BARS = {
 			new Tool('stretch_tool', {
 				icon: 'expand',
 				category: 'tools',
+				condition: () => Format.stretch_cubes,
 				selectFace: true,
 				transformerMode: 'stretch',
 				toolbar: 'main_tools',

--- a/js/interface/actions.js
+++ b/js/interface/actions.js
@@ -1848,6 +1848,16 @@ const BARS = {
 					}
 				}
 			})
+			new Tool('stretch_tool', {
+				icon: 'expand',
+				category: 'tools',
+				selectFace: true,
+				transformerMode: 'stretch',
+				toolbar: 'main_tools',
+				alt_tool: 'resize_tool',
+				modes: ['edit'],
+				keybind: new Keybind({key: 's', alt: true}),
+			})
 
 		//File
 			new Action('new_window', {
@@ -2050,6 +2060,7 @@ const BARS = {
 				'rotate_tool',
 				'pivot_tool',
 				'vertex_snap_tool',
+				'stretch_tool',
 				'seam_tool',
 				'pan_tool',
 				'brush_tool',

--- a/js/modeling/transform_gizmo.js
+++ b/js/modeling/transform_gizmo.js
@@ -961,7 +961,7 @@
 					if (Toolbox.selected.transformerMode === 'translate') {
 						Transformer.rotation_ref = display_area;
 
-					} else if (Toolbox.selected.transformerMode === 'scale' || Toolbox.selected.transformerMode === 'stretch') {
+					} else if (Toolbox.selected.transformerMode === 'scale') {
 						Transformer.rotation_ref = display_base;
 
 					} else if (Toolbox.selected.transformerMode === 'rotate' && display_slot == 'gui') {
@@ -980,7 +980,7 @@
 					} else if (Toolbox.selected.id === 'move_tool' && BarItems.transform_space.value === 'global') {
 						delete Transformer.rotation_ref;
 
-					} else if (Toolbox.selected.id == 'resize_tool' || Toolbox.selected.id === 'stretch_tool' || (Toolbox.selected.id === 'rotate_tool' && BarItems.rotation_space.value !== 'global')) {
+					} else if (Toolbox.selected.id == 'resize_tool' || (Toolbox.selected.id === 'rotate_tool' && BarItems.rotation_space.value !== 'global')) {
 						Transformer.rotation_ref = Group.selected.mesh;
 
 					} else {
@@ -1590,7 +1590,7 @@
 							Project.display_settings[display_slot][channel][axisNumber] += difference;
 						}
 
-						if ((event.shiftKey || Pressing.overrides.shift) && (channel === 'scale' || channel === 'stretch')) {
+						if ((event.shiftKey || Pressing.overrides.shift) && channel === 'scale') {
 							var val = Project.display_settings[display_slot][channel][(axisNumber||0)]
 							Project.display_settings[display_slot][channel][((axisNumber||0)+1)%3] = val
 							Project.display_settings[display_slot][channel][((axisNumber||0)+2)%3] = val
@@ -1634,7 +1634,7 @@
 
 					if (Modes.id === 'edit' || Modes.id === 'pose' || Toolbox.selected.id == 'pivot_tool') {
 						if (Toolbox.selected.id === 'resize_tool' || Toolbox.selected.id === 'stretch_tool') {
-							//Scale
+							//Scale and stretch
 							selected.forEach(function(obj) {
 								delete obj.oldScale;
 								delete obj.oldStretch;
@@ -1642,7 +1642,11 @@
 								delete obj.oldUVOffset;
 							})
 							if (scope.hasChanged && keep_changes) {
-								Undo.finishEdit('Resize')
+								if (Toolbox.selected.id === 'resize_tool') {
+									Undo.finishEdit('Resize')
+								} else if (Toolbox.selected.id === 'stretch_tool') {
+									Undo.finishEdit('Stretch')
+								}
 							}
 
 						} else if (scope.axis !== null && scope.hasChanged && keep_changes) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1155,6 +1155,8 @@
 	"action.move_tool.desc": "Tool to select and move elements",
 	"action.resize_tool": "Resize",
 	"action.resize_tool.desc": "Tool to select and resize elements",
+	"action.stretch_tool": "Stretch",
+	"action.stretch_tool.desc": "Tool to select and stretch elements",
 	"action.rotate_tool": "Rotate",
 	"action.rotate_tool.desc": "Tool to select and rotate elements",
 	"action.pivot_tool": "Pivot Tool",


### PR DESCRIPTION
This PR extends the transform gizmo functionality to support modifying a cube's stretch values. A corresponding tool was also added (default shortcut of `alt + s` to match scale which is just `s`). Probably not the best icon for it but I didn't see a better one in font awesome's collection.
