### PR TITLE
Fix a few bugs about io

### DIFF
--- a/js/io/formats/bedrock.js
+++ b/js/io/formats/bedrock.js
@@ -597,7 +597,7 @@ function calculateVisibleBox() {
 		}
 		if (b.locators) {
 			for (var key in b.locators) {
-				var coords, rotation, ignore_inherited_scale;
+				let coords, rotation, ignore_inherited_scale;
 				if (b.locators[key] instanceof Array) {
 					coords = b.locators[key];
 				} else {


### PR DESCRIPTION
* When importing a **bedrock** model, if there are both locators with rotation and without rotation in the same group, those locators without rotation may incorrectly get rotated. 
e.g.
```json
{
	"name": "bone",
	"pivot": [0, 0, 0],
	"locators": {
		"locator": {
			"offset": [0, 0, 0],
			"rotation": [-20, -35, 60]
		},
		"locator2": [0, 0, 0]
	}
}
```
* Parsing of **modded_entity** always encounter problems, such as bone rotation problem caused by `addChild` out of order. So I improved it a little bit. I haven't considered model formats for versions of 1.17+ because I haven't read the code for those versions yet.
