### PR TITLE
GLTF Export Bug : element not defined

### DIFF
--- a/js/io/formats/gltf.js
+++ b/js/io/formats/gltf.js
@@ -216,7 +216,7 @@ function buildSkinnedMesh(root_group, scale) {
 				if (tex && tex.uuid) {
 					materials.push(Project.materials[tex.uuid])
 				} else {
-					materials.push(Canvas.emptyMaterials[element.color])
+					materials.push(Canvas.emptyMaterials[child.color])
 				}
 				if (face.vertices && face.vertices.length == 3) {
 					face_vertex_counts.push(3);


### PR DESCRIPTION
Got an error on export on this line, likely copied from the mesh.js code. 
In this context the equivalent element is the child, this removes the error and results in a white-colored material for the exported, non-textured file.

