### PR TITLE
fix(gif-recorder): set transparent flag false when background image is provided

### DIFF
--- a/js/preview/screenshot.js
+++ b/js/preview/screenshot.js
@@ -563,7 +563,7 @@ const Screencam = {
 						// Direct flicker-free color mapping
 						index = applyPalette(data, palette, format);
 					}
-					gif.writeFrame(index, canvas.width, canvas.height, {palette, delay: interval});
+					gif.writeFrame(index, canvas.width, canvas.height, {palette, delay: interval, transparent: !background_image});
 					i++;
 					Blockbench.setProgress(i / frame_canvases.length);
 					await new Promise(resolve => setTimeout(resolve, 0));

--- a/js/preview/screenshot.js
+++ b/js/preview/screenshot.js
@@ -563,7 +563,7 @@ const Screencam = {
 						// Direct flicker-free color mapping
 						index = applyPalette(data, palette, format);
 					}
-					gif.writeFrame(index, canvas.width, canvas.height, {palette, delay: interval, transparent: true});
+					gif.writeFrame(index, canvas.width, canvas.height, {palette, delay: interval});
 					i++;
 					Blockbench.setProgress(i / frame_canvases.length);
 					await new Promise(resolve => setTimeout(resolve, 0));


### PR DESCRIPTION
closes #2076

**Changes:**
- Set transprency flag false when background image is provided, explained in this comment https://github.com/JannisX11/blockbench/issues/2076#issuecomment-2036919044