### PR TITLE
Allow Textures to be created outside of a Project

### DIFF
--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -185,7 +185,11 @@ class Texture {
 		});
 		mat.map = tex;
 		mat.name = this.name;
-		Project.materials[this.uuid] = mat;
+		if (!data.standalone) {
+			if (!Project) throw new Error('Attempted to create a Texture without a Project. If this is intentional, set the standalone option to true.');
+			Project.materials[this.uuid] = mat;
+		};
+
 
 		var size_control = {};
 


### PR DESCRIPTION
Animated Java needs to create a texture that isn't related to any specific project, however, the Texture constructor includes this line:
```js
Project.materials[this.uuid] = mat;
```
which causes an Error if `Project` isn't a ModelProject if I attempt to make the Texture before a Project has actually been loaded.

My PR is very simple:
```js
if (!data.standalone) {
  if (!Project) throw new Error('Attempted to create a Texture without a Project. If this is intentional, set the standalone option to true.');
  Project.materials[this.uuid] = mat;
};
```
Add an option to TextureOptions to avoid adding to a project, while still throwing an error otherwise, but using that Error to intentionally inform the plugin developer.

My current work-around solution is this extremely hacky bit of code:
```js

const OLD_PROJECT = Project
// @ts-ignore
Project = { materials: {} }
export const TRANSPARENT_TEXTURE = new Texture(
{
  id: `${PACKAGE.name}:transparent_texture`,
    name: 'Transparent',
  },
  '797174ae-5c58-4a83-a630-eefd51007c80'
)
Project = OLD_PROJECT
```