### PR TITLE
Added "solid with marker color" view mode from #2316

### DIFF
--- a/js/outliner/cube.js
+++ b/js/outliner/cube.js
@@ -1113,7 +1113,10 @@ new NodePreviewController(Cube, {
 		mesh.geometry.setIndex(indices)
 
 		if (Project.view_mode === 'solid') {
-			mesh.material = Canvas.solidMaterial
+			mesh.material = Canvas.monochromaticSolidMaterial
+		
+		} else if (Project.view_mode === 'colored_solid') {
+			mesh.material = Canvas.coloredSolidMaterials[element.color % Canvas.emptyMaterials.length]
 		
 		} else if (Project.view_mode === 'wireframe') {
 			mesh.material = Canvas.wireframeMaterial

--- a/js/outliner/mesh.js
+++ b/js/outliner/mesh.js
@@ -1061,7 +1061,10 @@ new NodePreviewController(Mesh, {
 		let {mesh} = element;
 
 		if (Project.view_mode === 'solid') {
-			mesh.material = Canvas.solidMaterial
+			mesh.material = Canvas.monochromaticSolidMaterial
+		
+		} else if (Project.view_mode === 'colored_solid') {
+			mesh.material = Canvas.coloredSolidMaterials[element.color]
 		
 		} else if (Project.view_mode === 'wireframe') {
 			mesh.material = Canvas.wireframeMaterial

--- a/js/outliner/texture_mesh.js
+++ b/js/outliner/texture_mesh.js
@@ -294,8 +294,11 @@ new NodePreviewController(TextureMesh, {
 		let {mesh} = element;
 
 		if (Project.view_mode === 'solid') {
-			mesh.material = Canvas.solidMaterial
+			mesh.material = Canvas.monochromaticSolidMaterial
 		
+		} else if (Project.view_mode === 'colored_solid') {
+			mesh.material = Canvas.coloredSolidMaterials[0]
+
 		} else if (Project.view_mode === 'wireframe') {
 			mesh.material = Canvas.wireframeMaterial
 

--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -36,6 +36,78 @@ const Reusable = {
 	euler2: new THREE.Euler(),
 }
 
+// Aza note:
+// ---------------------------------------
+// Not sure about the pertinence of doing this, but my reasoning is that it saves us 
+// from copying the exact same shaders twice for both solid view mode variants (monochromatic & colored).
+const SolidMaterialShaders = {
+	vertShader: `
+		attribute float highlight;
+
+		uniform bool SHADE;
+
+		varying float light;
+		varying float lift;
+
+		float AMBIENT = 0.1;
+		float XFAC = -0.05;
+		float ZFAC = 0.05;
+
+		void main()
+		{
+
+			if (SHADE) {
+
+				vec3 N = normalize( vec3( modelViewMatrix * vec4(normal, 0.0) ) );
+
+				light = (0.2 + abs(N.z) * 0.8) * (1.0-AMBIENT) + N.x*N.x * XFAC + N.y*N.y * ZFAC + AMBIENT;
+
+			} else {
+
+				light = 1.0;
+
+			}
+
+			if (highlight == 2.0) {
+				lift = 0.3;
+			} else if (highlight == 1.0) {
+				lift = 0.12;
+			} else {
+				lift = 0.0;
+			}
+			
+			vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
+			gl_Position = projectionMatrix * mvPosition;
+		}`,
+	fragShader: `
+		#ifdef GL_ES
+		precision ${isApp ? 'highp' : 'mediump'} float;
+		#endif
+
+		uniform bool SHADE;
+		uniform float BRIGHTNESS;
+		uniform vec3 base;
+
+		varying float light;
+		varying float lift;
+
+		void main(void)
+		{
+
+			gl_FragColor = vec4(lift + base * light * BRIGHTNESS, 1.0);
+
+			if (lift > 0.1) {
+				gl_FragColor.b = gl_FragColor.b * 1.16;
+				gl_FragColor.g = gl_FragColor.g * 1.04;
+			}
+			if (lift > 0.2) {
+				gl_FragColor.r = gl_FragColor.r * 0.6;
+				gl_FragColor.g = gl_FragColor.g * 0.7;
+			}
+
+		}`
+}
+
 const Canvas = {
 	// Stores various colors for the 3D scene
 	gizmo_colors,
@@ -58,81 +130,31 @@ const Canvas = {
 	wireframeMaterial: new THREE.MeshBasicMaterial({
 		wireframe: true
 	}),
-	solidMaterial: (function() {
-		var vertShader = `
-			attribute float highlight;
-
-			uniform bool SHADE;
-
-			varying float light;
-			varying float lift;
-
-			float AMBIENT = 0.1;
-			float XFAC = -0.05;
-			float ZFAC = 0.05;
-
-			void main()
-			{
-
-				if (SHADE) {
-
-					vec3 N = normalize( vec3( modelViewMatrix * vec4(normal, 0.0) ) );
-
-					light = (0.2 + abs(N.z) * 0.8) * (1.0-AMBIENT) + N.x*N.x * XFAC + N.y*N.y * ZFAC + AMBIENT;
-
-				} else {
-
-					light = 1.0;
-
-				}
-
-				if (highlight == 2.0) {
-					lift = 0.3;
-				} else if (highlight == 1.0) {
-					lift = 0.12;
-				} else {
-					lift = 0.0;
-				}
-				
-				vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-				gl_Position = projectionMatrix * mvPosition;
-			}`
-		var fragShader = `
-			#ifdef GL_ES
-			precision ${isApp ? 'highp' : 'mediump'} float;
-			#endif
-
-			uniform bool SHADE;
-			uniform float BRIGHTNESS;
-			uniform vec3 base;
-
-			varying float light;
-			varying float lift;
-
-			void main(void)
-			{
-
-				gl_FragColor = vec4(lift + base * light * BRIGHTNESS, 1.0);
-
-				if (lift > 0.1) {
-					gl_FragColor.b = gl_FragColor.b * 1.16;
-					gl_FragColor.g = gl_FragColor.g * 1.04;
-				}
-				if (lift > 0.2) {
-					gl_FragColor.r = gl_FragColor.r * 0.6;
-					gl_FragColor.g = gl_FragColor.g * 0.7;
-				}
-
-			}`
-
+	coloredSolidMaterials:[],
+	createColoredSolidMaterials() {
+		markerColors.forEach(function(color, i) {
+			if (Canvas.coloredSolidMaterials[i]) return;
+			Canvas.coloredSolidMaterials[i] = new THREE.ShaderMaterial({
+				uniforms: {
+					SHADE: {type: 'bool', value: settings.shading.value},
+					BRIGHTNESS: {type: 'bool', value: settings.brightness.value / 50},
+					base: {value: new THREE.Color().set(color.pastel)}
+				},
+				vertexShader: SolidMaterialShaders.vertShader,
+				fragmentShader: SolidMaterialShaders.fragShader,
+				side: THREE.DoubleSide
+			});
+		})
+	},
+	monochromaticSolidMaterial: (function() {
 		return new THREE.ShaderMaterial({
 			uniforms: {
 				SHADE: {type: 'bool', value: settings.shading.value},
 				BRIGHTNESS: {type: 'bool', value: settings.brightness.value / 50},
 				base: {value: gizmo_colors.solid}
 			},
-			vertexShader: vertShader,
-			fragmentShader: fragShader,
+			vertexShader: SolidMaterialShaders.vertShader,
+			fragmentShader: SolidMaterialShaders.fragShader,
 			side: THREE.DoubleSide
 		});
 	})(),
@@ -590,6 +612,7 @@ const Canvas = {
 
 	setup() {
 		Canvas.updateMarkerColorMaterials();
+		Canvas.createColoredSolidMaterials();
 
 		//Light
 		Sun = new THREE.AmbientLight( 0xffffff );
@@ -935,9 +958,12 @@ const Canvas = {
 		if (Canvas.layered_material) {
 			Canvas.layered_material.side = side;
 		}
-		if (Canvas.solidMaterial) {
-			Canvas.solidMaterial.side = side;
+		if (Canvas.monochromaticSolidMaterial) {
+			Canvas.monochromaticSolidMaterial.side = side;
 		}
+		Canvas.coloredSolidMaterials.forEach(function(mat) {
+			mat.side = side
+		})
 		Canvas.emptyMaterials.forEach(function(mat) {
 			mat.side = side
 		})
@@ -1219,8 +1245,11 @@ const Canvas = {
 		Canvas.adaptObjectFaceGeo(cube);
 
 		if (Project.view_mode === 'solid') {
-			mesh.material = Canvas.solidMaterial
-		
+			mesh.material = Canvas.monochromaticSolidMaterial
+
+		} else if (Project.view_mode === 'colored_solid') {
+			mesh.material = Canvas.coloredSolidMaterials[cube.color]
+
 		} else if (Project.view_mode === 'wireframe') {
 			mesh.material = Canvas.wireframeMaterial
 

--- a/js/preview/preview.js
+++ b/js/preview/preview.js
@@ -2070,8 +2070,12 @@ function updateShading() {
 		material.uniforms.SHADE.value = settings.shading.value;
 		material.uniforms.BRIGHTNESS.value = settings.brightness.value / 50;
 	})
-	Canvas.solidMaterial.uniforms.SHADE.value = settings.shading.value;
-	Canvas.solidMaterial.uniforms.BRIGHTNESS.value = settings.brightness.value / 50;
+	Canvas.coloredSolidMaterials.forEach(material => {
+		material.uniforms.SHADE.value = settings.shading.value;
+		material.uniforms.BRIGHTNESS.value = settings.brightness.value / 50;
+	})
+	Canvas.monochromaticSolidMaterial.uniforms.SHADE.value = settings.shading.value;
+	Canvas.monochromaticSolidMaterial.uniforms.BRIGHTNESS.value = settings.brightness.value / 50;
 	Canvas.uvHelperMaterial.uniforms.SHADE.value = settings.shading.value;
 	Canvas.normalHelperMaterial.uniforms.SHADE.value = settings.shading.value;
 	Blockbench.dispatchEvent('update_scene_shading');
@@ -2094,6 +2098,7 @@ BARS.defineActions(function() {
 		options: {
 			textured: {name: true, icon: 'image', condition: () => (!Toolbox.selected.allowed_view_modes || Toolbox.selected.allowed_view_modes.includes('textured'))},
 			solid: {name: true, icon: 'fas.fa-square', condition: () => (!Toolbox.selected.allowed_view_modes || Toolbox.selected.allowed_view_modes.includes('solid'))},
+			colored_solid: {name: true, icon: 'fas.fa-square-plus', condition: () => (!Toolbox.selected.allowed_view_modes || Toolbox.selected.allowed_view_modes.includes('colored_solid'))},
 			wireframe: {name: true, icon: 'far.fa-square', condition: () => (!Toolbox.selected.allowed_view_modes || Toolbox.selected.allowed_view_modes.includes('wireframe'))},
 			uv: {name: true, icon: 'grid_guides', condition: () => (!Toolbox.selected.allowed_view_modes || Toolbox.selected.allowed_view_modes.includes('uv'))},
 			normal: {name: true, icon: 'fa-square-caret-up', condition: () => ((!Toolbox.selected.allowed_view_modes || Toolbox.selected.allowed_view_modes.includes('normal')) && Mesh.all.length)},

--- a/lang/en.json
+++ b/lang/en.json
@@ -1618,6 +1618,7 @@
 	"action.view_mode.desc": "Change the model view mode",
 	"action.view_mode.textured": "Textured",
 	"action.view_mode.solid": "Solid",
+	"action.view_mode.colored_solid": "Solid with Marker Colors",
 	"action.view_mode.wireframe": "Wireframe",
 	"action.view_mode.uv": "UV Preview",
 	"action.view_mode.normal": "Face Orientation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1199,7 +1199,6 @@
 	"action.view_mode.desc": "Change le mode d'affichage du modèle",
 	"action.view_mode.textured": "Texturé",
 	"action.view_mode.solid": "Solide",
-	"action.view_mode.colored_solid": "Solide avec Couleur des marqueurs",
 	"action.view_mode.wireframe": "Squelette",
 	"action.toggle_sidebars": "Activer/désactiver les barres latérales",
 	"action.toggle_sidebars.desc": "Active/désactive les bandes sur les côtés",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1199,6 +1199,7 @@
 	"action.view_mode.desc": "Change le mode d'affichage du modèle",
 	"action.view_mode.textured": "Texturé",
 	"action.view_mode.solid": "Solide",
+	"action.view_mode.colored_solid": "Solide avec Couleur des marqueurs",
 	"action.view_mode.wireframe": "Squelette",
 	"action.toggle_sidebars": "Activer/désactiver les barres latérales",
 	"action.toggle_sidebars.desc": "Active/désactive les bandes sur les côtés",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Blockbench",
-	"version": "4.10.0-beta.1",
+	"version": "4.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Blockbench",
-			"version": "4.10.0-beta.1",
+			"version": "4.10.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@electron/remote": "^2.1.2",


### PR DESCRIPTION
This pull request adds the view mode requested in #2316 
At the moment localization seems to not be working (on my end only ?), even tho I have added entries in the lang files of which I speak the language, I haven't managed to find why.

What I did here is basically duplicate the "solid" view mode and its associated canvas & preview setup, but with an added marker color component, just like the default "texture" view mode already has

Demo Video (recorded on the netify preview to have working localization)

https://github.com/JannisX11/blockbench/assets/30528331/bd0afeed-e299-4e0b-af7f-1a69707d3933

