### PR TITLE
Update GPU Blacklist & Blocklist Flags

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,6 +172,9 @@ function createWindow(second_instance, options = {}) {
 	return win;
 }
 
+app.commandLine.appendSwitch("gpu")
+app.commandLine.appendSwitch("gpu-launcher")
+app.commandLine.appendSwitch("in-process-gpu")
 app.commandLine.appendSwitch('ignore-gpu-blacklist')
 app.commandLine.appendSwitch('ignore-gpu-blocklist')
 app.commandLine.appendSwitch('enable-accelerated-video')


### PR DESCRIPTION
The GPU blacklist & blocklist flags needed to be updated. The current code only passed in `--ignore-gpu-blacklist` and `--ignore-gpu-blocklist`, but `--gpu`, `--gpu-launcher`, and `--in-process-gpu` needed to be passed in as well for Blockbench to work.