### PR TITLE
Repeating Textures, new UV Tools and behaviors

### DIFF
--- a/js/texturing/texture_generator.js
+++ b/js/texturing/texture_generator.js
@@ -1684,8 +1684,8 @@ const TextureGenerator = {
 			uv_mode: true
 		})
 	},
-	
-	unwrapFaceDialog() {
+
+	unwrapMeshFacesDialog() {
 		let resolution_presets = {
 			16: '16x',
 			32: '32x',
@@ -1696,7 +1696,7 @@ const TextureGenerator = {
 		};
 		var dialog = new Dialog({
 			id: 'add_bitmap',
-			title: tl('action.unwrap_mesh'),
+			title: tl('action.unwrap_mesh_faces'),
 			width: 480,
 			form: {
 				resolution_vec: {label: 'dialog.create_texture.resolution', type: 'vector', dimensions: 2, value: [Project.texture_width, Project.texture_height], min: 1, max: 4096},
@@ -1708,12 +1708,12 @@ const TextureGenerator = {
 			},
 			onConfirm(options) {
 				dialog.hide()
-				TextureGenerator.unwrapFace(options);
+				TextureGenerator.unwrapMeshFaces(options);
 				return false;
 			}
 		}).show()
 	},
-	unwrapFace(options) {
+	unwrapMeshFaces(options) {
 		let res_multiple = options.resolution / 16.0;
 		console.log(res_multiple)
 

--- a/js/texturing/texture_generator.js
+++ b/js/texturing/texture_generator.js
@@ -1684,6 +1684,622 @@ const TextureGenerator = {
 			uv_mode: true
 		})
 	},
+	
+	unwrapFaceDialog() {
+		let resolution_presets = {
+			16: '16x',
+			32: '32x',
+			64: '64x',
+			128: '128x',
+			256: '256x',
+			512: '512x',
+		};
+		var dialog = new Dialog({
+			id: 'add_bitmap',
+			title: tl('action.unwrap_mesh'),
+			width: 480,
+			form: {
+				resolution_vec: {label: 'dialog.create_texture.resolution', type: 'vector', dimensions: 2, value: [Project.texture_width, Project.texture_height], min: 1, max: 4096},
+				resolution: {label: 'dialog.create_texture.pixel_density', description: 'dialog.create_texture.pixel_density.desc', type: 'select', value: 16, options: resolution_presets},
+				combine_polys: {label: 'dialog.create_texture.combine_polys', description: 'dialog.create_texture.combine_polys.desc', type: 'checkbox', value: true, condition: (form) => (Mesh.selected.length)},
+				max_edge_angle: {label: 'dialog.create_texture.max_edge_angle', description: 'dialog.create_texture.max_edge_angle.desc', type: 'number', value: 45, condition: (form) => Mesh.selected.length},
+				max_island_angle: {label: 'dialog.create_texture.max_island_angle', description: 'dialog.create_texture.max_island_angle.desc', type: 'number', value: 45, condition: (form) => Mesh.selected.length},
+				padding:	{label: 'dialog.create_texture.padding', description: 'dialog.create_texture.padding.desc', type: 'checkbox', value: false},
+			},
+			onConfirm(options) {
+				dialog.hide()
+				TextureGenerator.unwrapFace(options);
+				return false;
+			}
+		}).show()
+	},
+	unwrapFace(options) {
+		let res_multiple = options.resolution / 16.0;
+		console.log(res_multiple)
+
+		let element_list = ((Format.single_texture) ? Outliner.elements : Outliner.selected);
+		element_list = element_list.filter(el => {
+			return (el instanceof Mesh && el.visibility);
+		});
+		
+		Undo.initEdit({
+			elements: element_list,
+			uv_only: true,
+			bitmap: true,
+			uv_mode: true
+		})
+		
+		let face_list = [];
+		let vec1 = new THREE.Vector3(),
+			vec2 = new THREE.Vector3(),
+			vec3 = new THREE.Vector3(),
+			vec4 = new THREE.Vector3();
+		element_list.forEach(mesh => {
+			let mirror_modeling_duplicate = BarItems.mirror_modeling.value && MirrorModeling.cached_elements[mesh.uuid] && MirrorModeling.cached_elements[mesh.uuid].is_copy;
+			if (mirror_modeling_duplicate) return;
+
+			let face_groups = [];
+			for (let fkey in mesh.faces) {
+				let face = mesh.faces[fkey];
+				if (face.vertices.length < 3) continue;
+				
+				let face_old_pos_id;
+				if (BarItems.selection_mode.value !== 'object' && !face.isSelected(fkey)) continue;
+				face_groups.push({
+					type: 'face_group',
+					mesh,
+					faces: [face],
+					keys: [fkey],
+					face_old_pos_id,
+					edges: new Map(),
+					normal: face.getNormal(true),
+					vertex_uvs: {},
+				})
+			}
+			
+			function getEdgeLength(edge) {
+				let edge_vertices = edge.map(vkey => mesh.vertices[vkey]);
+				return Math.sqrt(
+					Math.pow(edge_vertices[1][0] - edge_vertices[0][0], 2) +
+					Math.pow(edge_vertices[1][1] - edge_vertices[0][1], 2) +
+					Math.pow(edge_vertices[1][2] - edge_vertices[0][2], 2)
+				)
+			}
+
+			// Sort straight faces first
+			function getNormalStraightness(normal) {
+				let absolute = normal.map(Math.abs);
+				return (
+					(absolute[0] < 0.5 ? absolute[0] : (1-absolute[0]))*1.6 +
+					(absolute[1] < 0.5 ? absolute[1] : (1-absolute[1])) +
+					(absolute[2] < 0.5 ? absolute[2] : (1-absolute[2]))
+				)
+			}
+			face_groups.sort((a, b) => {
+				return getNormalStraightness(a.normal) - getNormalStraightness(b.normal);
+			})
+			
+			function projectFace(face, fkey, face_group, connection) {
+				// Project vertex coords onto plane
+				let {vertex_uvs} = face_group;
+				let normal_vec = vec1.fromArray(face.getNormal(true));
+				let plane = new THREE.Plane().setFromNormalAndCoplanarPoint(
+					normal_vec,
+					vec2.fromArray(mesh.vertices[face.vertices[0]])
+				)
+				let sorted_vertices = face.getSortedVertices();
+				let rot = cameraTargetToRotation([0, 0, 0], normal_vec.toArray());
+				let e = new THREE.Euler(Math.degToRad(rot[1] - 90), Math.degToRad(rot[0] + 180), 0);
+
+				let face_vertex_uvs = {};
+
+				face.vertices.forEach(vkey => {
+					let coplanar_pos = plane.projectPoint(vec3.fromArray(mesh.vertices[vkey]), vec4);
+					coplanar_pos.applyEuler(e);
+					face_vertex_uvs[vkey] = [
+						Math.roundTo(coplanar_pos.x, 4),
+						Math.roundTo(coplanar_pos.z, 4),
+					]
+				})
+
+				if (connection) {
+					// Rotate to connect to previous face
+					let other_face_vertex_uvs = vertex_uvs[connection.fkey];
+					let uv_hinge = face_vertex_uvs[connection.edge[0]];
+					let uv_latch = face_vertex_uvs[connection.edge[1]];
+					let uv_lock = other_face_vertex_uvs[connection.edge[1]];
+
+					// Join hinge
+					let offset = uv_hinge.slice().V2_subtract(other_face_vertex_uvs[connection.edge[0]]);
+					for (let vkey in face_vertex_uvs) {
+						face_vertex_uvs[vkey].V2_subtract(offset);
+					}
+
+					// Join latch
+					uv_hinge = uv_hinge.slice();
+					let angle = Math.atan2(
+						uv_hinge[0] - uv_latch[0],
+						uv_hinge[1] - uv_latch[1],
+					) - Math.atan2(
+						uv_hinge[0] - uv_lock[0],
+						uv_hinge[1] - uv_lock[1],
+					);
+					let s = Math.sin(angle);
+					let c = Math.cos(angle);
+					for (let vkey in face_vertex_uvs) {
+						let point = face_vertex_uvs[vkey].slice().V2_subtract(uv_hinge);
+						face_vertex_uvs[vkey][0] = point[0] * c - point[1] * s;
+						face_vertex_uvs[vkey][1] = point[0] * s + point[1] * c;
+						face_vertex_uvs[vkey].V2_add(uv_hinge);
+					}
+
+					// Check overlap
+					function isSameUVVertex(point_a, point_b) {
+						return (Math.epsilon(point_a[0], point_b[0], 0.1)
+								&& Math.epsilon(point_a[1], point_b[1], 0.1))
+					}
+					let i = -1;
+					for (let other_face of face_group.faces) {
+						i++;
+						if (other_face == connection.face) continue;
+						let other_fkey = face_group.keys[i];
+						let sorted_vertices_b = other_face.getSortedVertices();
+						let l1 = 0;
+						for (let vkey_1_a of sorted_vertices) {
+							let vkey_1_b = sorted_vertices[l1+1] || sorted_vertices[0]
+							let l2 = 0;
+							for (let vkey_2_a of sorted_vertices_b) {
+								let vkey_2_b = sorted_vertices_b[l2+1] || sorted_vertices_b[0];
+
+								if (intersectLines(
+									face_vertex_uvs[vkey_1_a],
+									face_vertex_uvs[vkey_1_b],
+									face_group.vertex_uvs[other_fkey][vkey_2_a],
+									face_group.vertex_uvs[other_fkey][vkey_2_b]
+								)) {
+									if (
+										!isSameUVVertex(face_vertex_uvs[vkey_1_a], face_group.vertex_uvs[other_fkey][vkey_2_a]) &&
+										!isSameUVVertex(face_vertex_uvs[vkey_1_a], face_group.vertex_uvs[other_fkey][vkey_2_b]) &&
+										!isSameUVVertex(face_vertex_uvs[vkey_1_b], face_group.vertex_uvs[other_fkey][vkey_2_a]) &&
+										!isSameUVVertex(face_vertex_uvs[vkey_1_b], face_group.vertex_uvs[other_fkey][vkey_2_b])
+									) {
+										return false;
+									}
+								}
+								l2++;
+							}
+							l1++;
+						}
+					}
+				}
+
+				face_group.vertex_uvs[fkey] = face_vertex_uvs;
+				return true;
+			}
+
+			let processed_faces = [];
+			if (options.combine_polys) {
+				face_groups.slice().forEach((face_group) => {
+					if (!face_groups.includes(face_group)) return;
+
+					function growFromFaces(faces) {
+						let perimeter = {};
+						for (let fkey in faces) {
+							let face = faces[fkey];
+							let face_connection_count = 0;
+							processed_faces.push(face);
+							let face_normal = face.getNormal(true);
+							[2, 0, 3, 1].forEach(i => {
+								if (!face.vertices[i]) return;
+								let other_face_match = face.getAdjacentFace(i);
+								let edge = other_face_match && face.vertices.filter(vkey => other_face_match.face.vertices.includes(vkey));
+								if (other_face_match && edge.length == 2 && !face_group.faces.includes(other_face_match.face) && !processed_faces.includes(other_face_match.face)) {
+									let other_face = other_face_match.face;
+									let other_face_group = face_groups.find(group => group.faces[0] == other_face);
+									if (!other_face_group) return;
+									let seam = mesh.getSeam(other_face_match.edge);
+									if (seam === 'divide') return;
+									if (seam !== 'join') {
+
+										let angle = face.getAngleTo(other_face);
+										if (angle > (options.max_edge_angle||36)) return;
+
+										let angle_total = face_group.faces[0].getAngleTo(other_face);
+										if (angle_total > (options.max_island_angle||45)) return;
+
+										let edge_length = getEdgeLength(other_face_match.edge);
+										if (edge_length < 2.2 && face_connection_count >= 2) return;
+
+										let other_face_normal = other_face.getNormal(true);
+										if (Math.abs(other_face_normal[0]) > 0.04 &&
+											Math.epsilon(face_normal[0], -other_face_normal[0], 0.04) &&
+											Math.epsilon(face_normal[1], other_face_normal[1], 0.04) &&
+											Math.epsilon(face_normal[2], other_face_normal[2], 0.04)
+										) return;
+									}
+									let projection_success = projectFace(other_face, other_face_match.key, face_group, {face, fkey, edge});
+									if (!projection_success) return;
+
+									face_group.faces.push(other_face);
+									face_group.keys.push(other_face_match.key);
+									face_groups.remove(other_face_group);
+									perimeter[other_face_match.key] = other_face;
+									face_connection_count++;
+								}
+							})
+						}
+						if (Object.keys(perimeter).length) growFromFaces(perimeter);
+					}
+					projectFace(face_group.faces[0], face_group.keys[0], face_group);
+					growFromFaces({[face_group.keys[0]]: face_group.faces[0]});
+				});
+			} else {
+				face_groups.forEach(face_group => {
+					face_group.faces.forEach((face, i) => {
+						let fkey = face_group.keys[i];
+						projectFace(face, fkey, face_group);
+					})
+				})
+			}
+
+			face_groups.forEach(face_group => {
+				let {vertex_uvs} = face_group;
+				// Rotate UV to match corners
+				if (face_group.faces.length == 1) {
+					let rotation_angles = {};
+					let precise_rotation_angle = {};
+					face_group.faces.forEach((face, i) => {
+						let fkey = face_group.keys[i];
+						let vertices = face.getSortedVertices();
+						vertices.forEach((vkey, i) => {
+							let vkey2 = vertices[i+1] || vertices[0];
+							let edge_length = getEdgeLength([vkey, vkey2]);
+							let rot = Math.atan2(
+								vertex_uvs[fkey][vkey2][0] - vertex_uvs[fkey][vkey][0],
+								vertex_uvs[fkey][vkey2][1] - vertex_uvs[fkey][vkey][1],
+							)
+							let snap = 2;
+							rot = (Math.radToDeg(rot) + 360) % 90;
+							let rounded
+							let last_difference = snap;
+							for (let rounded_angle in precise_rotation_angle) {
+								let precise = precise_rotation_angle[rounded_angle];
+								if (Math.abs(rot - precise) < last_difference) {
+									last_difference = Math.abs(rot - precise);
+									rounded = rounded_angle;
+								}
+							}
+							if (!rounded) rounded = Math.round(rot / snap) * snap;
+							if (rotation_angles[rounded]) {
+								rotation_angles[rounded] += edge_length;
+							} else {
+								rotation_angles[rounded] = edge_length;
+								precise_rotation_angle[rounded] = rot;
+							}
+						})
+					})
+					let angles = Object.keys(rotation_angles).map(k => parseInt(k));
+					angles.sort((a, b) => {
+						let diff = rotation_angles[b] - rotation_angles[a];
+						if (diff) {
+							return diff;
+						} else {
+							return a < b ? -1 : 1;
+						}
+					})
+					if (rotation_angles[angles[0]] > 1) {
+						let angle = Math.degToRad(precise_rotation_angle[angles[0]]);
+						let s = Math.sin(angle);
+						let c = Math.cos(angle);
+						for (let fkey in vertex_uvs) {
+							for (let vkey in vertex_uvs[fkey]) {
+								let point = vertex_uvs[fkey][vkey].slice();
+								vertex_uvs[fkey][vkey][0] = point[0] * c - point[1] * s;
+								vertex_uvs[fkey][vkey][1] = point[0] * s + point[1] * c;
+							}
+						}
+					}
+				}
+
+				// Define UV bounding box
+				let min_x = Infinity;
+				let min_z = Infinity;
+				for (let fkey in vertex_uvs) {
+					for (let vkey in vertex_uvs[fkey]) {
+						min_x = Math.min(min_x, vertex_uvs[fkey][vkey][0]);
+						min_z = Math.min(min_z, vertex_uvs[fkey][vkey][1]);
+					}
+				}
+				for (let fkey in vertex_uvs) {
+					for (let vkey in vertex_uvs[fkey]) {
+						vertex_uvs[fkey][vkey][0] -= min_x;
+						vertex_uvs[fkey][vkey][1] -= min_z;
+					}
+				}
+
+				// Round
+				if (face_group.faces.length == 1 && face_group.faces[0].vertices.length == 4) {
+					let sorted_vertices = face_group.faces[0].getSortedVertices();
+					sorted_vertices.forEach((vkey, vi) => {
+						let vkey2 = sorted_vertices[vi+1] || sorted_vertices[0];
+						let vkey0 = sorted_vertices[vi-1] || sorted_vertices.last();
+						let snap = 1;
+						let vertex_uvs_1 = vertex_uvs[face_group.keys[0]];
+
+						if (Math.epsilon(vertex_uvs_1[vkey][0], vertex_uvs_1[vkey2][0], 0.001)) {
+							let min = vertex_uvs_1[vkey][0] > vertex_uvs_1[vkey0][0] ? 1 : 0;
+							vertex_uvs_1[vkey][0] = vertex_uvs_1[vkey2][0] = Math.round(Math.max(min, vertex_uvs_1[vkey][0] * snap)) / snap;
+						}
+						if (Math.epsilon(vertex_uvs_1[vkey][1], vertex_uvs_1[vkey2][1], 0.001)) {
+							let min = vertex_uvs_1[vkey][1] > vertex_uvs_1[vkey0][1] ? 1 : 0;
+							vertex_uvs_1[vkey][1] = vertex_uvs_1[vkey2][1] = Math.round(Math.max(min, vertex_uvs_1[vkey][1] * snap)) / snap;
+						}
+					})
+				}
+
+
+				max_x = -Infinity;
+				max_z = -Infinity;
+				for (let fkey in vertex_uvs) {
+					for (let vkey in vertex_uvs[fkey]) {
+						max_x = Math.max(max_x, vertex_uvs[fkey][vkey][0]);
+						max_z = Math.max(max_z, vertex_uvs[fkey][vkey][1]);
+					}
+				}
+				// Center island if it faces front of back
+				if (Math.epsilon(face_group.normal[0], 0, 0.08)) {
+					let offset_x = (Math.ceil(max_x*res_multiple)/res_multiple - max_x) / 2;
+					for (let fkey in vertex_uvs) {
+						for (let vkey in vertex_uvs[fkey]) {
+							vertex_uvs[fkey][vkey][0] += offset_x;
+						}
+					}
+				}
+				// ... or on the side
+				else if (Math.epsilon(face_group.normal[2], 0, 0.05)) {
+					let offset_x = (Math.ceil(max_x*res_multiple)/res_multiple - max_x) / 2;
+					for (let fkey in vertex_uvs) {
+						for (let vkey in vertex_uvs[fkey]) {
+							vertex_uvs[fkey][vkey][0] += offset_x;
+						}
+					}
+				}
+				// Or align right if face points to right side of model
+				else if ((face_group.normal[0] > 0) != (face_group.normal[2] < 0)) {
+					for (let fkey in vertex_uvs) {
+						for (let vkey in vertex_uvs[fkey]) {
+							vertex_uvs[fkey][vkey][0] += Math.ceil(max_x*res_multiple)/res_multiple - max_x;
+						}
+					}
+				}
+				// Align bottom if face points downwards
+				if (face_group.normal[1] < 0) {
+					for (let fkey in vertex_uvs) {
+						for (let vkey in vertex_uvs[fkey]) {
+							vertex_uvs[fkey][vkey][1] += Math.ceil(max_z*res_multiple)/res_multiple - max_z;
+						}
+					}
+				}
+				face_group.posx = 0;
+				face_group.posy = 0;
+				face_group.vertex_uvs = vertex_uvs;
+				face_group.width = max_x;
+				face_group.height = max_z;
+				face_group.size = max_x * max_z;
+
+				let axis = [0, 1, 2].sort((a, b) => {
+					return Math.abs(face_group.normal[b]) - Math.abs(face_group.normal[a]) - 0.0001
+				})[0]
+				if (axis == 0 && face_group.normal[0] >= 0) face_group.face_key = 'east';
+				if (axis == 0 && face_group.normal[0] <= 0) face_group.face_key = 'west';
+				if (axis == 1 && face_group.normal[1] >= 0) face_group.face_key = 'up';
+				if (axis == 1 && face_group.normal[1] <= 0) face_group.face_key = 'down';
+				if (axis == 2 && face_group.normal[2] >= 0) face_group.face_key = 'south';
+				if (axis == 2 && face_group.normal[2] <= 0) face_group.face_key = 'north';
+
+
+			})
+			face_list.push(...face_groups);
+		})
+
+		if (face_list.length == 0) {
+			Blockbench.showMessage('message.no_valid_elements', 'center')
+			return;
+		}
+
+		function getPolygonOccupationMatrix(vertex_uv_faces, width, height) {
+			let matrix = {};
+			function vSub(a, b) {
+				return [a[0]-b[0], a[1]-b[1]];
+			}
+			function getSide(a, b) {
+				let cosine_sign = a[0]*b[1] - a[1]*b[0];
+				if (cosine_sign > 0) return 1;
+				if (cosine_sign < 0) return -1;
+			}
+			function pointInsidePolygon(x, y) {
+				face_uvs:
+				for (let vertex_uvs of vertex_uv_faces) {
+					let previous_side;
+					let i = 0;
+					vertices:
+					for (let a of vertex_uvs) {
+						let b = vertex_uvs[i+1] || vertex_uvs[0];
+						let affine_segment = vSub(b, a);
+						let affine_point = vSub([x, y], a);
+						let side = getSide(affine_segment, affine_point);
+						if (!side) continue face_uvs;
+						if (!previous_side) previous_side = side;
+						if (side !== previous_side) continue face_uvs;
+						i++;
+					}
+					return true;
+				}
+				return false;
+			}
+			for (let x = 0; x < (0 + width); x++) {
+				for (let y =0; y < (0 + height); y++) {
+					let inside = ( pointInsidePolygon(x+0.00001, y+0.00001)
+								|| pointInsidePolygon(x+0.99999, y+0.00001)
+								|| pointInsidePolygon(x+0.00001, y+0.99999)
+								|| pointInsidePolygon(x+0.99999, y+0.99999));
+					if (!inside) {
+						let px_rect = [[x, y], [x+0.99999, y+0.99999]]
+						faces:
+						for (let vertex_uvs of vertex_uv_faces) {
+							let i = 0;
+							for (let a of vertex_uvs) {
+								let b = vertex_uvs[i+1] || vertex_uvs[0];
+								if (pointInRectangle(a, ...px_rect)) {
+									inside = true; break faces;
+								}
+								if (lineIntersectsReactangle(a, b, ...px_rect)) {
+									inside = true; break faces;
+								}
+								i++;
+							}
+						}
+					}
+					if (inside) {
+						if (!matrix[x]) matrix[x] = {};
+						matrix[x][y] = true;
+					}
+				}
+			}
+			return matrix;
+		}
+		face_list.forEach(face_group => {
+			if (!face_group.mesh) return;
+			let face_uvs = face_group.faces.map((face, i) => {
+				return face.getSortedVertices().map(vkey => {
+					return face_group.vertex_uvs[face_group.keys[i]][vkey];
+				})
+			});
+			face_group.matrix = getPolygonOccupationMatrix(face_uvs, face_group.width, face_group.height);
+		})
+
+		face_list.sort(function(a,b) {
+			return b.size - a.size;
+		})
+
+		var fill_map = {};
+		function occupy(x, y) {
+			if (!fill_map[x]) fill_map[x] = {}
+			fill_map[x][y] = true
+		}
+		function check(x, y) {
+			return fill_map[x] && fill_map[x][y]
+		}
+		function forTemplatePixel(tpl, sx, sy, cb) {
+			let w = tpl.width;
+			let h = tpl.height;
+
+			if (options.padding) {
+				w++; h++;
+				for (var x = 0; x < w; x++) {
+					if (tpl.matrix && !tpl.matrix[x] && !tpl.matrix[x-1]) continue;
+					for (var y = 0; y < h; y++) {
+						if (
+							tpl.matrix && 
+							(!tpl.matrix[x] || !tpl.matrix[x][y]) &&
+							(!tpl.matrix[x-1] || !tpl.matrix[x-1][y]) &&
+							(!tpl.matrix[x] || !tpl.matrix[x][y-1]) &&
+							(!tpl.matrix[x-1] || !tpl.matrix[x-1][y-1])
+						) continue;
+						if (cb(sx+x, sy+y)) return;
+					}
+				}
+			} else {
+				for (var x = 0; x < w; x++) {
+					if (tpl.matrix && !tpl.matrix[x]) continue;
+					for (var y = 0; y < h; y++) {
+						if (tpl.matrix && !tpl.matrix[x][y]) continue;
+						if (cb(sx+x, sy+y)) return;
+					}
+				}
+			}
+		}
+		function place(tpl, x, y) {
+			var works = true;
+			forTemplatePixel(tpl, x, y, (tx, ty) => {
+				if (check(tx, ty)) {
+					works = false;
+					return true;
+				}
+			})
+			if (works) {
+				forTemplatePixel(tpl, x, y, occupy)
+				tpl.posx = x;
+				tpl.posy = y;
+				return true;
+			}
+		}
+		face_list.forEach(tpl => {
+			//Scan for empty spot
+			for (var line = 0; line < 2e3; line++) {
+				for (var space = 0; space <= line; space++) {
+					if (place(tpl, space, line)) return;
+					if (space == line) continue;
+					if (place(tpl, line, space)) return;
+				}
+			}
+		})
+
+		face_list.forEach(function(ftemp) {		
+			function applyUV(source, target) {
+				target.faces.forEach((face, i) => {
+					let source_face = source.faces[i];
+					let source_fkey = source.keys[i];
+					face.vertices.forEach((vkey, j) => {
+						let source_vkey = vkey;
+						if (ftemp.copy_to) {
+							for (let vkey2 of source_face.vertices) {
+								let vertex_uv_a = source_face.uv[vkey2];
+								let vertex_uv_b = face.uv[vkey];
+								if (Math.epsilon(vertex_uv_a[0], vertex_uv_b[0], 0.002) && Math.epsilon(vertex_uv_a[1], vertex_uv_b[1], 0.002)) {
+									source_vkey = vkey2;
+									break;
+								}
+							}
+						}
+						if (!face.uv[vkey]) face.uv[vkey] = [];
+						// Final UV sizes and positions, per face.
+						let uv_size_multiplier = res_multiple;
+						let uv_offset_multiplier = res_multiple;
+						face.uv[vkey][0] = source.vertex_uvs[source_fkey][source_vkey][0] * uv_size_multiplier + (source.posx * uv_offset_multiplier);
+						face.uv[vkey][1] = source.vertex_uvs[source_fkey][source_vkey][1] * uv_size_multiplier + (source.posy * uv_offset_multiplier);
+					})
+				})
+			}
+			if (ftemp.copy_to) {
+				for (let ftemp2 of ftemp.copy_to) {
+					applyUV(ftemp, ftemp2);
+				}
+			}
+			applyUV(ftemp, ftemp);
+		})
+
+		// Updates the texture in the object, I think.
+		element_list.forEach(function(element) {
+			if (!Format.single_texture) {
+				element.preview_controller.updateFaces(element);
+			}
+			element.preview_controller.updateUV(element);
+		})
+
+		Project.texture_width = options.resolution_vec[0];
+		Project.texture_height = options.resolution_vec[1];
+
+		updateSelection()
+		setTimeout(Canvas.updatePixelGrid, 1);
+		Undo.finishEdit('Unwrap Mesh', {
+			bitmap: true,
+			elements: [...element_list],
+			uv_only: true,
+			uv_mode: true
+		})
+	},
+	
 	generateColorMapTemplate(options, cb) {
 
 		var background_color = options.color;

--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -214,6 +214,9 @@ class Texture {
 				this.uv_width = scope.width;
 				this.uv_height = scope.display_height;
 			}
+			
+			tex.wrapS = this.repeating ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+			tex.wrapT = this.repeating ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 
 			if (scope.isDefault) {
 				console.log('Successfully loaded '+scope.name+' from default pack')

--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -21,6 +21,7 @@ class Texture {
 		this.height = 0;
 		this.uv_width = Project ? Project.texture_width : 16;
 		this.uv_height = Project ? Project.texture_height : 16;
+		this.repeating = false;
 		this.currentFrame = 0;
 		this.saved = true;
 		this.layers = [];
@@ -56,8 +57,8 @@ class Texture {
 		img.src = 'assets/missing.png'
 
 		var tex = new THREE.Texture(this.canvas);
-		tex.magFilter = THREE.NearestFilter
-		tex.minFilter = THREE.NearestFilter
+		tex.magFilter = THREE.NearestFilter;
+        tex.minFilter = THREE.NearestFilter;
 		tex.name = this.name;
 		img.tex = tex;
 
@@ -722,6 +723,8 @@ class Texture {
 		mat.side = this.render_sides == 'auto' ? Canvas.getRenderSide() : (this.render_sides == 'front' ? THREE.FrontSide : THREE.DoubleSide);
 
 		// Map
+		mat.map.wrapS = this.repeating ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+        mat.map.wrapT = this.repeating ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
 		mat.map.needsUpdate = true;
 		return this;
 	}
@@ -1143,6 +1146,7 @@ class Texture {
 		if (Format.per_texture_uv_size) {
 			form.uv_size = {type: 'vector', label: 'dialog.texture.uv_size', value: [this.uv_width, this.uv_height], dimensions: 2, step: 1, min: 1};
 		}
+		form.repeating = {label: 'dialog.texture.repeating', type: 'checkbox', value: this.repeating};
 		if (Format.texture_mcmeta) {
 			Object.assign(form, {
 				'texture_mcmeta': '_',
@@ -1171,7 +1175,7 @@ class Texture {
 			onConfirm: results => {
 
 				dialog.hide();
-				if (['name', 'variable', 'folder', 'namespace', 'frame_time', 'frame_interpolate', 'frame_order_type', 'frame_order'].find(key => {
+				if (['name', 'variable', 'folder', 'namespace', 'frame_time', 'frame_interpolate', 'frame_order_type', 'frame_order', 'repeating'].find(key => {
 					return results[key] !== undefined && results[key] !== this[key];
 				}) == undefined) {
 					return;
@@ -1187,6 +1191,7 @@ class Texture {
 				if (results.namespace !== undefined) this.namespace = results.namespace;
 				if (results.render_mode !== undefined) this.render_mode = results.render_mode;
 				if (results.render_sides !== undefined) this.render_sides = results.render_sides;
+				if (results.repeating !== undefined) this.repeating = results.repeating;
 				
 				if (Format.per_texture_uv_size) {
 					let changed = this.uv_width != results.uv_size[0] || this.uv_height != results.uv_size[1];
@@ -2063,6 +2068,7 @@ class Texture {
 	new Property(Texture, 'string', 'sync_to_project')
 	new Property(Texture, 'enum', 'render_mode', {default: 'default'})
 	new Property(Texture, 'enum', 'render_sides', {default: 'auto'})
+	new Property(Texture, 'boolean', 'repeating')
 	
 	new Property(Texture, 'number', 'frame_time', {default: 1})
 	new Property(Texture, 'enum', 'frame_order_type', {default: 'loop', values: ['custom', 'loop', 'backwards', 'back_and_forth']})

--- a/js/texturing/uv.js
+++ b/js/texturing/uv.js
@@ -1595,7 +1595,7 @@ BARS.defineActions(function() {
 		category: 'uv',
 		condition: () => Mesh.selected.length,
 		click() {
-			TextureGenerator.unwrapFaceDialog()
+			TextureGenerator.unwrapMeshFacesDialog()
 		}
 	})
 	new Action('uv_project_from_view', {

--- a/js/texturing/uv.js
+++ b/js/texturing/uv.js
@@ -1590,6 +1590,14 @@ BARS.defineActions(function() {
 			Undo.finishEdit('Auto UV')
 		}
 	})
+	new Action('unwrap_mesh_faces', {
+		icon: 'view_in_ar',
+		category: 'uv',
+		condition: () => Mesh.selected.length,
+		click() {
+			TextureGenerator.unwrapFaceDialog()
+		}
+	})
 	new Action('uv_project_from_view', {
 		icon: 'view_in_ar',
 		category: 'uv',

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Datei laden und alle Änderungen und Ebenen in Blockbench verwerfen",
 	"message.group_required_to_animate": "Diese Art von Element kann nicht animiert werden. Erstelle stattdessen eine Gruppe.",
 	"dialog.texture.uv_size": "UV-Größe",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Kamerablickwinkel",
 	"dialog.advanced_screenshot.resolution": "Auflösung",
 	"dialog.advanced_screenshot.zoom_to_fit": "Passend zoomen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1739,6 +1739,7 @@
 	"action.uv_cycle_invert.desc": "Reverse the order of UV vertices without changing the UV positions",
 	"action.paint_mode_uv_overlay": "UV Overlay",
 	"action.paint_mode_uv_overlay.desc": "Display the UV map as an overlay in paint mode",
+	"action.snap_uv_to_image_bounds": "Snap UV to image bounds",
 	"action.edit_mode_uv_overlay.desc": "Display the UV map as an overlay in edit mode",
 	"action.remove_blank_faces": "Remove Blank Faces",
 	"action.remove_blank_faces.desc": "Deletes all untextured faces of the selection",

--- a/lang/en.json
+++ b/lang/en.json
@@ -451,6 +451,7 @@
 	"dialog.texture.namespace": "Namespace",
 	"dialog.texture.folder": "Folder",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.texture.frame_time": "Frame Time",
 	"dialog.texture.frame_time.desc": "Set for how long each frame will be visible, in ticks. Each tick is 1/20th of a second.",
 	"dialog.texture.frame_interpolate": "Interpolate",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1707,6 +1707,7 @@
 	"action.uv_rel_auto.desc": "Sets the UV of this face to the position and size of the actual face",
 	"action.uv_project_from_view": "UV Project from View",
 	"action.uv_project_from_view.desc": "Automatically generate UVs for the selected faces from the perspective of the 3D view",
+	"action.unwrap_mesh_faces": "UV Unwrap Mesh Faces",
 	"action.uv_mirror_x": "UV Mirror X",
 	"action.uv_mirror_x.desc": "Mirrors the UV of this face on the X axis",
 	"action.uv_mirror_y": "UV Mirror Y",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Résolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoomer pour ajuster",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "ファイルをロードし、Blockbench のすべての変更とレイヤーを破棄します",
 	"message.group_required_to_animate": "このタイプのエレメントをアニメーション化することはできません。 グループを作成してアニメーション化します。",
 	"dialog.texture.uv_size": "UV サイズ",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "アングルプリセット",
 	"dialog.advanced_screenshot.resolution": "解像度",
 	"dialog.advanced_screenshot.zoom_to_fit": "フィットズーム",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -100,6 +100,7 @@
 	"dialog.texture.variable": "Variável",
 	"dialog.texture.namespace": "Ambiente",
 	"dialog.texture.folder": "Pasta",
+	"dialog.texture.repeating": "Repetição",
 	"dialog.extrude.title": "Extrudar imagem",
 	"dialog.extrude.mode": "Modo de digitalização",
 	"dialog.extrude.mode.areas": "Áreas",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Загрузить файл и отменить все изменения и слои в Blockbench",
 	"message.group_required_to_animate": "Вы не можете анимировать этот тип элемента. Создайте группу для анимации.",
 	"dialog.texture.uv_size": "Размер UV",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Предустановка угла",
 	"dialog.advanced_screenshot.resolution": "Разрешение",
 	"dialog.advanced_screenshot.zoom_to_fit": "Масштаб по размеру",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Завантажити файл і скасувати всі зміни та шари в Blockbench",
 	"message.group_required_to_animate": "Цей тип елементів не можна анімувати. Створіть групу, щоб анімувати його.",
 	"dialog.texture.uv_size": "UV-Розмір",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Попередньо заданий кут",
 	"dialog.advanced_screenshot.resolution": "Роздільність",
 	"dialog.advanced_screenshot.zoom_to_fit": "Розмір зображення",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Tải tệp và loại bỏ tất cả các thay đổi và lớp trong Blockbench",
 	"message.group_required_to_animate": "Bạn không thể tạo hiệu ứng chuyển động cho phần tử này. Hãy tạo một nhóm để tạo hiệu ứng chuyển động.",
 	"dialog.texture.uv_size": "Kích cỡ UV",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Góc giá trị cài sẵn",
 	"dialog.advanced_screenshot.resolution": "Độ phân giải",
 	"dialog.advanced_screenshot.zoom_to_fit": "Thu phóng tới khi vừa",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV尺寸",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/lang/zh_tw.json
+++ b/lang/zh_tw.json
@@ -1966,6 +1966,7 @@
 	"message.texture_refresh_conflict.keep_theirs": "Load file and discard all changes and layers in Blockbench",
 	"message.group_required_to_animate": "You cannot animate this type of element. Create a group to animate it.",
 	"dialog.texture.uv_size": "UV Size",
+	"dialog.texture.repeating": "Repeat",
 	"dialog.advanced_screenshot.angle_preset": "Angle Preset",
 	"dialog.advanced_screenshot.resolution": "Resolution",
 	"dialog.advanced_screenshot.zoom_to_fit": "Zoom To Fit",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Blockbench",
-	"version": "4.10.2",
+	"version": "4.10.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Blockbench",
-			"version": "4.10.2",
+			"version": "4.10.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@electron/remote": "^2.1.2",
@@ -4293,11 +4293,11 @@
 			"dev": true
 		},
 		"node_modules/electron-updater": {
-			"version": "6.1.8",
-			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.8.tgz",
-			"integrity": "sha512-hhOTfaFAd6wRHAfUaBhnAOYc+ymSGCWJLtFkw4xJqOvtpHmIdNHnXDV9m1MHC+A6q08Abx4Ykgyz/R5DGKNAMQ==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.0.tgz",
+			"integrity": "sha512-3Xlezhk+dKaSQrOnkQNqCGiuGSSUPO9BV9TQZ4Iig6AyTJ4FzJONE5gFFc382sY53Sh9dwJfzKsA3DxRHt2btw==",
 			"dependencies": {
-				"builder-util-runtime": "9.2.3",
+				"builder-util-runtime": "9.2.5",
 				"fs-extra": "^10.1.0",
 				"js-yaml": "^4.1.0",
 				"lazy-val": "^1.0.5",
@@ -4308,9 +4308,9 @@
 			}
 		},
 		"node_modules/electron-updater/node_modules/builder-util-runtime": {
-			"version": "9.2.3",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
-			"integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
+			"version": "9.2.5",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz",
+			"integrity": "sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"sax": "^1.2.4"


### PR DESCRIPTION
- Disclaimer: I don't know how to change the name of new properties.

## Texture
### Added an option for Repeating Textures.
- Option available in the Texture Properties:
![image](https://github.com/user-attachments/assets/d405464f-03a2-4450-9b4c-2ca2f85d5e74)
- Option Off (original behavior): 
![image](https://github.com/user-attachments/assets/0da341a2-8c19-4eba-8923-794ddf56c95c)
- Option On (new behavior):
![image](https://github.com/user-attachments/assets/c32b83dd-96eb-410c-a6b1-449a903e0acd)

- This closes #1391
- (It's not yet possible to paint the repeating regions in the mesh itself. The brush won't paint anything unless using the brush in a "valid" region of the mesh, where it's not repeating any segment of the texture)


## UV
### New tool to toggle 'Snap UV to Image Bounds'
- When the tool is disabled, is possible to:
  - Cube with Box-UV: 
      - 'drag move / scale / rotate' UV Faces
  - Cube with Per-face-UV:
      - 'drag move / scale / rotate' UV Faces and UV Edges
  - Meshes with Per-face-UV:
      - 'drag move / scale / rotate' UV Faces and UV Vertices 
- In other words, if the tool is disabled it's now possible to make UV transforms without the UV being locked inside the image bounds.
- If the tool is enabled, then the old behavior takes place.
- (It's possible to invert the toggle, but I figure the tool name would be confusing)


### New tool to 'Unwrap Mesh Faces', without creating a texture
- In a nutshell, it's the code from 'texture_generator/generateFaceTemplate', but discarding all the steps to create a new texture and apply it to the object.
- The tool also has the option to set a "Target Resolution" and "Pixel Density", working just like the 'Texel Density addon for Blender', or similar tools in Maya.
  - The 'Target Resolution' refers to the resolution aimed to be used, while 'Pixel Density' refers to the scale of which the UV should be, based on the Target Resolution.
- There are also these other options available:
![image](https://github.com/user-attachments/assets/241824df-99da-4038-a827-897f8fcf651e)


### Removal of the Zoom Out limit in the UV panel
- Considering the additions of all UV tools, It makes more sense to disable to limit to Zoom Out in the UV panel, as it's necessary to be able to make any comfortable modifications for the UV.


## I have some questions:

- How can I rename the new tool and new properties? I don't know if I'm supposed to add anything else besides the translation. First I only added translation for EN, but I decided to try adding translation for all available languages, just as an attempt, but it didn't work.
- The 'package-lock.json' file was updated for me, but I don't know if it's something I should commit.


## End

That's it, tell me what you think :)