### PR TITLE
Make the default gltf export path to be relative

### DIFF
--- a/js/io/codec.js
+++ b/js/io/codec.js
@@ -123,7 +123,7 @@ class Codec extends EventSystem {
 		return Project.name||'model';
 	}
 	startPath() {
-		return Project.export_path;
+		return Project.save_path;
 	}
 	write(content, path) {
 		if (fs.existsSync(path) && this.overwrite) {


### PR DESCRIPTION
I just changed 1 line of code.

Now, the **default** save path for saving a .gltf / .glb file is the same as the .bbmodel save path.

## Why:

- I just think is annoying to navigate from the previous .bbmodel path to the current one.
- I don't see why file paths from different files should relate.
- I use Blockbench with Godot, so it makes *much* more sense regarding how assets are usually handled.
- But yeah, completely subjective, but it makes more sense to me to be this way. 
