### PR TITLE
More accurate ground display for Java block/item

### DIFF
--- a/js/display_mode.js
+++ b/js/display_mode.js
@@ -1348,11 +1348,11 @@ var setDisplayArea = DisplayMode.setBase = function(x, y, z, rx, ry, rz, sx, sy,
 	Transformer.center()
 }
 DisplayMode.groundAnimation = function() {
-	display_area.rotation.y += 0.01
+	display_area.rotation.y += 0.005
 	ground_timer += 1
-	display_area.position.y = 2.5 + Math.sin(Math.PI * (ground_timer / 200)) * 2
+	display_area.position.y = 2.5 + Math.sin(Math.PI * (ground_timer / 300)) * 2;
 	Transformer.center()
-	if (ground_timer === 200) ground_timer = 0;
+	if (ground_timer === 600) ground_timer = 0;
 }
 DisplayMode.updateGUILight = function() {
 	if (!Modes.display) return;

--- a/js/display_mode.js
+++ b/js/display_mode.js
@@ -1348,9 +1348,9 @@ var setDisplayArea = DisplayMode.setBase = function(x, y, z, rx, ry, rz, sx, sy,
 	Transformer.center()
 }
 DisplayMode.groundAnimation = function() {
-	display_area.rotation.y += 0.015
+	display_area.rotation.y += 0.01
 	ground_timer += 1
-	display_area.position.y = 5.5 + Math.sin(Math.PI * (ground_timer / 100)) * Math.PI/2
+	display_area.position.y = 2.5 + Math.sin(Math.PI * (ground_timer / 200)) * 2
 	Transformer.center()
 	if (ground_timer === 200) ground_timer = 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Blockbench",
-	"version": "4.10.2",
+	"version": "4.10.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Blockbench",
-			"version": "4.10.2",
+			"version": "4.10.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@electron/remote": "^2.1.2",


### PR DESCRIPTION
I know this is suuuper minor, but it's always bugged the hell out of me that the ground display in Blockbench is a little bit inaccurate. It can make creating custom item models a tiny bit more annoying.

Here's a comparison of the high and low peaks for Blockbench and Java
I set the y translation of both to 0 (normally 3 in Java) to more easily see the difference.
![image](https://github.com/user-attachments/assets/7b9ac69d-bb9a-492a-9351-ad215081cb99)

I only changed the speed of rotation and bouncing a bit (still too fast) since it's not really that important. Plus, it makes it easier to see if the item clips into the ground or not