### PR TITLE
Feat/texture path config

### DIFF
--- a/js/interface/settings.js
+++ b/js/interface/settings.js
@@ -565,13 +565,14 @@ const Settings = {
 			spaces_4: tl('settings.json_indentation.spaces_4'),
 			spaces_2: tl('settings.json_indentation.spaces_2'),
 		}});
-		new Setting('final_newline',		{category: 'export', value: false});
-		new Setting('minifiedout',			{category: 'export', value: false});
-		new Setting('embed_textures', 		{category: 'export', value: true});
-		new Setting('minify_bbmodel', 		{category: 'export', value: true});
-		new Setting('export_empty_groups',	{category: 'export', value: true});
-		new Setting('export_groups', 		{category: 'export', value: true});
-		new Setting('java_export_pivots', 	{category: 'export', value: true});
+		new Setting('final_newline',			{category: 'export', value: false});
+		new Setting('minifiedout',				{category: 'export', value: false});
+		new Setting('embed_textures',			{category: 'export', value: true});
+		new Setting('absolute_texture_paths',	{category: 'export', value: true});
+		new Setting('minify_bbmodel', 			{category: 'export', value: true});
+		new Setting('export_empty_groups',		{category: 'export', value: true});
+		new Setting('export_groups', 			{category: 'export', value: true});
+		new Setting('java_export_pivots', 		{category: 'export', value: true});
 		new Setting('optifine_save_default_texture',{category: 'export', value: true});
 		new Setting('obj_face_export_mode',	{category: 'export', value: 'both', type: 'select', options: {
 			both: tl('settings.obj_face_export_mode.both'),

--- a/js/io/formats/bbmodel.js
+++ b/js/io/formats/bbmodel.js
@@ -186,7 +186,9 @@ var codec = new Codec('project', {
 				t.source = tex.getDataURL()
 				t.internal = true;
 			}
-			if (options.absolute_paths == false) delete t.path;
+			if (options.absolute_paths != true && (!Settings.get('absolute_texture_paths') || options.absolute_paths == false)) {
+				delete t.path;
+			}
 			model.textures.push(t);
 		})
 		for (let texture_group of TextureGroup.all) {

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Verstecke die Beziergriffe von Keyframes, die nicht ausgewählt sind",
 	"settings.embed_textures": "Texturen einbetten",
 	"settings.embed_textures.desc": "Bette den Inhalt von Texturen in die .bbmodel-Datei ein",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Zusammenhängend",
 	"dialog.copied_to_clipboard": "In Zwischenablage kopiert",
 	"data.reference_image": "Referenzbild",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1079,6 +1079,8 @@
 	"settings.minify_bbmodel.desc": "Write .bbmodel files minified into one line",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"settings.export_empty_groups": "Export Empty Groups",
 	"settings.export_empty_groups.desc": "Include groups without content in exported files",
 	"settings.export_groups": "Export Groups in Java block/item models",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Masque les poignées de Bézier des images clés qui ne sont pas actuellement sélectionnées",
 	"settings.embed_textures": "Intégrer les textures",
 	"settings.embed_textures.desc": "Intégrer le contenu des fichiers de texture dans les fichiers .bbmodel",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copié dans le presse-papiers",
 	"data.reference_image": "Image de référence",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "選択されていないベジェハンドルを非表示にします",
 	"settings.embed_textures": "テクスチャの埋め込み",
 	"settings.embed_textures.desc": "テクスチャファイルを .bbmodel ファイルに埋め込みます",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "クラスター",
 	"dialog.copied_to_clipboard": "クリップボードにコピーしました",
 	"data.reference_image": "参考画像",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "현재 선택되지 않은 베지어 키프레임의 핸들 숨기기",
 	"settings.embed_textures": "텍스쳐 임베드",
 	"settings.embed_textures.desc": "텍스쳐 파일 콘텐츠를 .bbmodel 파일에 임베드",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "클러스터",
 	"dialog.copied_to_clipboard": "클립보드에 복사됨",
 	"data.reference_image": "참조용 이미지",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Handvatten van bézier-hoofdframes verbergen die momenteel niet zijn geselecteerd",
 	"settings.embed_textures": "Sluit Texturen In",
 	"settings.embed_textures.desc": "Inhoud van textuurbestanden insluiten in .bbmodel-bestanden",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Kluster",
 	"dialog.copied_to_clipboard": "Kopieer naar klembord",
 	"data.reference_image": "Referentiebeeld",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Скрыть маркеры ключевых кадров Безье, которые в данный момент не выбраны",
 	"settings.embed_textures": "Встроить текстуры",
 	"settings.embed_textures.desc": "Встроить содержимое файла текстуры в файлы .bbmodel",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Кластер",
 	"dialog.copied_to_clipboard": "Скопировано в буфер обмена",
 	"data.reference_image": "Эталонное изображение",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Приховати дескриптори кадрів Безьє, які наразі не вибрано",
 	"settings.embed_textures": "Вбудувати текстури",
 	"settings.embed_textures.desc": "Вбудувати вміст файлів текстур у файли .bbmodel",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Кластер",
 	"dialog.copied_to_clipboard": "Скопійовано до буфера обміну",
 	"data.reference_image": "Еталонне зображення",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Ẩn tay cầm của các khung hình chính Bézier hiện không được chọn",
 	"settings.embed_textures": "Nhúng kết cấu",
 	"settings.embed_textures.desc": "Nhúng nội dung tệp kết cấu vào tệp .bbmodel",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cụm",
 	"dialog.copied_to_clipboard": "Đã sao chép vào bảng tạm",
 	"data.reference_image": "Ảnh tham chiếu",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "隐藏未选中的贝塞尔手柄",
 	"settings.embed_textures": "嵌入纹理",
 	"settings.embed_textures.desc": "嵌入纹理到 .bbmodel 工程文件",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "复制到剪贴板",
 	"data.reference_image": "参考图像",

--- a/lang/zh_tw.json
+++ b/lang/zh_tw.json
@@ -1760,6 +1760,8 @@
 	"settings.only_selected_bezier_handles.desc": "Hide handles of bézier keyframes that are not currently selected",
 	"settings.embed_textures": "Embed Textures",
 	"settings.embed_textures.desc": "Embed texture file content in .bbmodel files",
+	"settings.absolute_texture_paths": "Absolute Texture Paths",
+	"settings.absolute_texture_paths.desc": "Include absolute texture paths in .bbmodel files",
 	"action.selection_mode.cluster": "Cluster",
 	"dialog.copied_to_clipboard": "Copied to clipboard",
 	"data.reference_image": "Reference Image",


### PR DESCRIPTION
Added a new `absolute_texture_paths` app setting that controls whether or not the `$.textures[].path` field is written to `.bbmodel` project files.

Piggy-backed off the existing functionality to remove the field, which seems to exist for sharing project files, but mimicked the way the `embed_textures` setting is checked for just above it.

The surrounding settings in `js/interface/settings.js` seem to be column-aligned, so I updated the other settings to match the new alignment required for this slightly-longer setting name.

Based on looking at the non-English translation files, I assumed English stubs should be included in each language's file, so did so.