### PR TITLE
Fix texture bleeding when using anti-aliasing

### DIFF
--- a/js/interface/settings.js
+++ b/js/interface/settings.js
@@ -422,6 +422,7 @@ const Settings = {
 			Canvas.updateShading()
 		}});
 		new Setting('antialiasing', 	{category: 'preview', value: true});
+		new Setting('antialiasing_bleed_fix', 	{category: 'preview', value: true});
 		new Setting('fov', 		  		{category: 'preview', value: 45, type: 'number', min: 1, max: 120, onChange(val) {
 			Preview.all.forEach(preview => preview.setFOV(val));
 		}});

--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -241,7 +241,7 @@ const Canvas = {
 			uniform bool SHADE;
 			uniform float DENSITY;
 
-			varying vec2 vUv;
+			centroid varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -287,7 +287,7 @@ const Canvas = {
 
 			uniform bool SHADE;
 
-			varying vec2 vUv;
+			centroid varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -241,7 +241,7 @@ const Canvas = {
 			uniform bool SHADE;
 			uniform float DENSITY;
 
-			centroid varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 
@@ -287,7 +287,7 @@ const Canvas = {
 
 			uniform bool SHADE;
 
-			centroid varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -138,7 +138,7 @@ class Texture {
 			uniform bool EMISSIVE;
 			uniform vec3 LIGHTCOLOR;
 
-			varying vec2 vUv;
+			centroid varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -67,7 +67,7 @@ class Texture {
 			uniform bool SHADE;
 			uniform int LIGHTSIDE;
 
-			centroid varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 
@@ -138,7 +138,7 @@ class Texture {
 			uniform bool EMISSIVE;
 			uniform vec3 LIGHTCOLOR;
 
-			centroid varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -67,7 +67,7 @@ class Texture {
 			uniform bool SHADE;
 			uniform int LIGHTSIDE;
 
-			varying vec2 vUv;
+			centroid varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -924,6 +924,8 @@
 	"settings.shading.desc": "Enable shading in the preview",
 	"settings.antialiasing": "Anti-aliasing",
 	"settings.antialiasing.desc": "Toggle anti-aliasing in the preview. Restart Blockbench to apply changes",
+	"settings.antialiasing_bleed_fix": "Fix anti-aliasing bleeding",
+	"settings.antialiasing_bleed_fix.desc": "Fixes texture bleeding when using anti-aliasing. Restart Blockbench to apply changes",
 	"settings.render_sides": "Render Sides",
 	"settings.fov": "FOV",
 	"settings.fov.desc": "Camera Field of View. Default is 45",


### PR DESCRIPTION
This PR modifies the Textured and UV Preview vertex shaders to add the centroid qualifier to prevent UVs from getting extrapolated when using anti-aliasing.

I'm not certain but if mipmaps are ever introduced, I believe it could cause issues with trying to compute the mip levels. If this becomes an issue the simplest solution would be to pass non-centroid UVs and use those for the mip map derivatives and use the centroid UVs to prevent sampling texels outside of the triangles boundaries.

Should this anti-aliasing fix be tied to a setting or should it always be enabled?

![centroid_comparison](https://github.com/user-attachments/assets/fdbda750-8cc3-401b-aecb-d610c5a9cda2)
