### PR TITLE
Added -webkit-optimize-contrast image rendering

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -365,6 +365,7 @@
 		border-top: 1px solid var(--color-border);
 	}
 	.markdown img {
+		image-rendering: -webkit-optimize-contrast;
 		max-width: 100%;
 	}
 


### PR DESCRIPTION
Added image-rendering: -webkit-optimize-contrast to markdown images. This makes text in images more readable.

![image_rendering](https://github.com/user-attachments/assets/2c48a47a-b2de-47a9-84da-53294fdeb6bd)
