### PR TITLE
Fixed Java brush matrix

### DIFF
--- a/js/preview/preview.js
+++ b/js/preview/preview.js
@@ -1153,9 +1153,6 @@ class Preview {
 
 			let z_offset = world_normal.clone().multiplyScalar(z_fight_offset);
 			let matrix_offset = new THREE.Matrix4().makeTranslation(z_offset.x, z_offset.y, z_offset.z);
-			if (!Format.centered_grid) {
-				matrix_offset.makeTranslation(-Canvas.scene.position.x, -Canvas.scene.position.y, -Canvas.scene.position.z);
-			}
 			brush_matrix.multiplyMatrices(matrix_offset, brush_matrix);
 
 			Canvas.brush_outline.matrix = brush_matrix;

--- a/js/preview/preview.js
+++ b/js/preview/preview.js
@@ -1155,6 +1155,9 @@ class Preview {
 			let matrix_offset = new THREE.Matrix4().makeTranslation(z_offset.x, z_offset.y, z_offset.z);
 			brush_matrix.multiplyMatrices(matrix_offset, brush_matrix);
 
+			// Since we're setting the brush matrix, we need to multiply in its parents matrix as well in case there are any.
+			if (Canvas.brush_outline.parent)
+				brush_matrix.multiplyMatrices(Canvas.brush_outline.parent.matrixWorld.clone().invert(), brush_matrix);
 			Canvas.brush_outline.matrix = brush_matrix;
 		}
 		


### PR DESCRIPTION
- Replaced the temporary brush outline offset fix with a proper solution that makes the brush account for every kind of scene transformation.
- Fixed issue where z-offset was not being applied anymore when working with java models.