### PR TITLE
🐛 Fix the issue with the value of `this` in the callback function. Th…

### DIFF
--- a/js/interface/form.ts
+++ b/js/interface/form.ts
@@ -912,7 +912,7 @@ class FormElementFile extends FormElement {
 		})
 
 		input_wrapper.on('click', e => {
-			function fileCB(files) {
+			const fileCB = (files) => {
 				this.value = files[0].path;
 				this.content = files[0].content;
 				this.file = files[0];


### PR DESCRIPTION
…e `fileCB` callback function is defined in the context of `input_wrapper.on('click', ...)`, but it is not called in the context of `input_wrapper`. If `fileCB` is a regular function, its `this` will not point to `input_wrapper`, but rather to the global object or `undefined` (in **strict** mode). We want `this` to refer to `input_wrapper`, so we can use an arrow function or use the `bind` method when calling `fileCB`.