### PR TITLE
fix #2777 Cannot select elements due to marker colour index error

### DIFF
--- a/js/outliner/mesh.js
+++ b/js/outliner/mesh.js
@@ -1176,7 +1176,10 @@ new NodePreviewController(Mesh, {
 				if (tex && tex.uuid) {
 					materials.push(tex.getMaterial())
 				} else {
-					materials.push(Canvas.emptyMaterials[element.color])
+					// in most cases the color will be within the bounds of the emptyMaterials array,
+					// there is an edge case if you're loading a model that was saved with a color that is out of bounds
+					// see https://github.com/JannisX11/blockbench/issues/2777
+					materials.push(Canvas.emptyMaterials[element.color % Canvas.emptyMaterials.length])
 				}
 			}
 			if (materials.allEqual(materials[0])) materials = materials[0];


### PR DESCRIPTION
fixes #2777 

enforces mesh color material lookups are within bounds, its possible via use of a plugin to make a color index that is higher than 9.