### PR TITLE
Fixed incompatibility with AA bleeding fix

### DIFF
--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -244,7 +244,7 @@ const Canvas = {
 			uniform bool SHADE;
 			uniform float DENSITY;
 
-			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value && Preview.selected?.renderer.capabilities.isWebGL2 ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 
@@ -290,7 +290,7 @@ const Canvas = {
 
 			uniform bool SHADE;
 
-			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value && Preview.selected?.renderer.capabilities.isWebGL2 ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 

--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -67,7 +67,7 @@ class Texture {
 			uniform bool SHADE;
 			uniform int LIGHTSIDE;
 
-			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value && Preview.selected.renderer.capabilities.isWebGL2 ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 
@@ -138,7 +138,7 @@ class Texture {
 			uniform bool EMISSIVE;
 			uniform vec3 LIGHTCOLOR;
 
-			${settings.antialiasing_bleed_fix.value ? 'centroid' : ''} varying vec2 vUv;
+			${settings.antialiasing_bleed_fix.value && Preview.selected.renderer.capabilities.isWebGL2 ? 'centroid' : ''} varying vec2 vUv;
 			varying float light;
 			varying float lift;
 


### PR DESCRIPTION
• Made fix for anti-aliasing bleeding only apply when using WebGL 2 since it relies on the `centroid` qualifier which isn't available when using WebGL 1.
• The `uvHelperMaterial` material no longer uses the bleeding fix as it gets initialized before the rendering context is, so we're unable to check compatibility there. I did include the check in there in case the material initializing code is refactored at some point though.