### PR TITLE
Fix centroid incompatibility

### DIFF
--- a/js/shaders/shader.ts
+++ b/js/shaders/shader.ts
@@ -1,7 +1,7 @@
 import { settings } from "../interface/settings";
 
 export function prepareShader(shader: string): string {
-	if (settings.antialiasing_bleed_fix.value == false) {
+	if ((settings.antialiasing_bleed_fix.value && Preview.selected?.renderer.capabilities.isWebGL2) == false) {
 		shader = shader.replace(/centroid /g, '');
 	}
 	if (!isApp) {

--- a/js/shaders/texture.vert.glsl
+++ b/js/shaders/texture.vert.glsl
@@ -3,7 +3,7 @@ attribute float highlight;
 uniform bool SHADE;
 uniform int LIGHTSIDE;
 
-varying vec2 vUv;
+centroid varying vec2 vUv;
 varying float light;
 varying float lift;
 


### PR DESCRIPTION
• Reintroduced `centroid` interpolation qualifier to texture vertex shader.
• Made fix for anti-aliasing bleeding only apply when using WebGL 2 since it relies on the `centroid` qualifier which isn't available when using WebGL 1.