### PR TITLE
Fix brush outline not showing up when using WebGL 1

### DIFF
--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -419,6 +419,7 @@ export const Canvas = {
 			polygonOffset: true,
 			polygonOffsetUnits: 1,
 			polygonOffsetFactor: -1,
+			extensions: { derivatives: true },
 
 			uniforms: {
 				color: { value: new THREE.Color() },


### PR DESCRIPTION
This fix enables the `OES_standard_derivatives` extension when using a WebGL 1 context, but leaves WebGL 2 untouched since it is available by default then.