### PR TITLE
Performance: parse variable placeholders once on text change

### DIFF
--- a/js/animations/animation_mode.js
+++ b/js/animations/animation_mode.js
@@ -1463,7 +1463,6 @@ Interface.definePanels(function() {
 						Project.variable_placeholders = processed;
 						this.updateButtons();
 						Project.variable_placeholder_buttons.replace(this.buttons);
-						Animator.preview()
 					}
 				}
 			},

--- a/js/animations/animation_mode.js
+++ b/js/animations/animation_mode.js
@@ -12,6 +12,7 @@ const Animator = {
 	onion_skin_object: new THREE.Object3D(),
 	motion_trail_lock: false,
 	_last_values: {},
+	global_variable_lines: {},
 	resetLastValues() {
 		for (let channel in BoneAnimator.prototype.channels) {
 			if (BoneAnimator.prototype.channels[channel].transform) Animator._last_values[channel] = [0, 0, 0];
@@ -1458,9 +1459,11 @@ Interface.definePanels(function() {
 			watch: {
 				text(text) {
 					if (Project && typeof text == 'string') {
-						Project.variable_placeholders = text;
+						const processed = processVariablePlaceholderText(text)
+						Project.variable_placeholders = processed;
 						this.updateButtons();
 						Project.variable_placeholder_buttons.replace(this.buttons);
+						Animator.preview()
 					}
 				}
 			},
@@ -1493,3 +1496,23 @@ Interface.definePanels(function() {
 		}
 	})
 })
+
+function processVariablePlaceholderText(text) {
+	const res = text
+			.replaceAll(/(\s*)(v\.)/g, '$1variable.')
+			.replaceAll(/(\s*)(q\.)/g, '$1query.')
+			.replaceAll(/(\s*)(t\.)/g, '$1temp.')
+			.replaceAll(/(\s*)(c\.)/g, '$1context.')
+
+	Animator.global_variable_lines = {}
+	for (const line of res.split('\n')) {
+		let [key, val] = line.split(/=\s*(.+)/)
+		if(val === undefined) {
+			continue
+		}
+		key = key.replace(/[\s;]/g, '')
+		Animator.global_variable_lines[key] = val.trim()
+	}
+
+	return res
+}

--- a/js/animations/animation_mode.js
+++ b/js/animations/animation_mode.js
@@ -36,6 +36,7 @@ const Animator = {
 		Animator.open = true;
 		Canvas.updateAllBones();
 		Animator.MolangParser.resetVariables();
+		processVariablePlaceholderText(Project.variable_placeholders);
 
 		scene.add(WinterskyScene.space);
 		WinterskyScene.global_options.tick_rate = settings.particle_tick_rate.value;
@@ -1459,8 +1460,8 @@ Interface.definePanels(function() {
 			watch: {
 				text(text) {
 					if (Project && typeof text == 'string') {
-						const processed = processVariablePlaceholderText(text)
-						Project.variable_placeholders = processed;
+						Project.variable_placeholders = text;
+						processVariablePlaceholderText(text)
 						this.updateButtons();
 						Project.variable_placeholder_buttons.replace(this.buttons);
 					}

--- a/js/animations/molang.js
+++ b/js/animations/molang.js
@@ -90,35 +90,22 @@ Animator.MolangParser.global_variables = {
 	},
 }
 Animator.MolangParser.variableHandler = function (variable, variables) {
-	var inputs = Interface.Panels.variable_placeholders.inside_vue.text.split('\n')
-	var i = 0
-	while (i < inputs.length) {
-		let key, val
-		;[key, val] = inputs[i].split(/=\s*(.+)/)
-		key = key.replace(/[\s;]/g, '')
-		key = key
-			.replace(/^v\./, 'variable.')
-			.replace(/^q\./, 'query.')
-			.replace(/^t\./, 'temp.')
-			.replace(/^c\./, 'context.')
+	const val = Animator.global_variable_lines[variable]
+	if (val === undefined) {
+		return
+	}
 
-		if (key === variable && val !== undefined) {
-			val = val.trim()
+	if (val.match(/^(slider|toggle|impulse)\(/)) {
+		let [type, content] = val.substring(0, val.length - 1).split(/\(/)
+		let [id] = content.split(/\(|, */)
+		id = id.replace(/['"]/g, '')
 
-			if (val.match(/^(slider|toggle|impulse)\(/)) {
-				let [type, content] = val.substring(0, val.length - 1).split(/\(/)
-				let [id] = content.split(/\(|, */)
-				id = id.replace(/['"]/g, '')
-
-				let button = Interface.Panels.variable_placeholders.inside_vue.buttons.find(
-					(b) => b.id === id && b.type == type
-				)
-				return button ? parseFloat(button.value) : 0
-			} else {
-				return val[0] == `'` ? val : Animator.MolangParser.parse(val, variables)
-			}
-		}
-		i++
+		let button = Interface.Panels.variable_placeholders.inside_vue.buttons.find(
+			(b) => b.id === id && b.type == type
+		)
+		return button ? parseFloat(button.value) : 0
+	} else {
+		return val[0] == `'` ? val : Animator.MolangParser.parse(val, variables)
 	}
 }
 


### PR DESCRIPTION
before, it was running a bunch of redundant regex per variable per line, just to find a variable's definition
e.g. (a line with `<variable>=<value>`)

since all `variableHandler` needs is the variable's `val`, we can pre-process the raw text when it changes and store that for later

otherwise, `variableHandler` is called recursively *many* times depending on how your variable placeholder text is structured.