### PR TITLE
fix: inset mesh

### DIFF
--- a/js/modeling/mesh_editing.js
+++ b/js/modeling/mesh_editing.js
@@ -2690,7 +2690,7 @@ BARS.defineActions(function() {
 	
 					new_vertices = mesh.addVertices(...original_vertices.map(vkey => {
 						let vector = mesh.vertices[vkey].slice();
-						affected_faces = selected_faces.filter(face => {
+						let affected_faces = selected_faces.filter(face => {
 							return face.vertices.includes(vkey)
 						})
 						if (affected_faces.length == 0) return;


### PR DESCRIPTION
In the `next` branch, the inset face functionality simply fails, this does not happen in `master`.

tbh, I am deeply confused how this code ever worked. But in does in `master`

---

I just played around a bit more and found another occurrence of the same problem

https://github.com/JannisX11/blockbench/blob/621ba43e18848d114987ed899d91a5dbffd46479/js/texturing/color.js#L903

Maybe you should consider adding a linter, e.g. [esLint](https://eslint.org/) I would believe that it would catch such things. 
If you wish, I could give it a shot adding a linter.

Should I just add the fix for the other one in this PR?