### PR TITLE
🩹 `Menu` & `MenuBar` implements `Deletable`

### DIFF
--- a/js/interface/menu.js
+++ b/js/interface/menu.js
@@ -51,6 +51,7 @@ function handleMenuOverflow(node) {
 		offset(-e.deltaY);
 	})
 }
+// FIXME - This should be changed to `Menu implements Deletable` when this is converted to TypeScript
 export class Menu {
 	constructor(id, structure, options) {
 		if (typeof id !== 'string') {
@@ -725,6 +726,9 @@ export class Menu {
 		}
 		traverse(this.structure, 0)
 		rm_item.menus.remove(scope)
+	}
+	delete() {
+		this.node.remove()
 	}
 	static open = null;
 }

--- a/js/interface/menu_bar.js
+++ b/js/interface/menu_bar.js
@@ -45,6 +45,11 @@ export class BarMenu extends Menu {
 		this.highlight_action = action;
 		this.label.classList.add('highlighted');
 	}
+	delete() {
+		super.delete();
+		this.label.remove();
+		delete MenuBar.menus[this.id];
+	}
 }
 
 export const MenuBar = {


### PR DESCRIPTION
Adds `delete` functions to `Menu` and `MenuBar` classes.

Allows plugins to correctly remove any instances of these classes they create from Blockbench when unloaded.

Note: The types did not have to be updated as they already (incorrectly) indicated that these classes implemented `Deletable`.