### PR TITLE
CSS tweaks and fixes for Blockbench 5.0

### DIFF
--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -453,6 +453,8 @@
 		overflow-x: hidden;
 		overflow-y: auto;
 		border-bottom-left-radius: 6px;
+		margin-top: -10px;
+		padding-top: 10px;
 	}
 	.dialog_content {
 		display: block;

--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -1753,7 +1753,7 @@
 	.plugins_suggested_row > ul {
 		display: flex;
 		gap: 12px;
-		overflow-x: scroll;
+		overflow-x: auto;
 		padding: 12px 32px;
 		width: calc(100% + 48px);
 		margin-right: -24px;

--- a/css/panels.css
+++ b/css/panels.css
@@ -56,7 +56,7 @@
 	.panel_tab_bar {
 		display: flex;
 		width: 100%;
-		height: 40px;
+		height: 36px;
 		flex-shrink: 0;
 		margin: 0;
 		padding: 0;
@@ -91,6 +91,7 @@
 		border-top-left-radius: 5px;
 		border-top-right-radius: 5px;
 		cursor: pointer;
+		align-items: center;
 	}
 	.panel_tab_list > .panel_handle:hover {
 		color: var(--color-text);
@@ -182,7 +183,7 @@
 		cursor: pointer;
 		color: var(--color-subtle_text);
 		height: 100%;
-		padding-top: 3px;
+		padding-top: 1px;
 		margin-right: -10px;
 	}
 	.panel_handle:not(.selected) .panel_menu_button {

--- a/css/panels.css
+++ b/css/panels.css
@@ -62,6 +62,17 @@
 		padding: 0;
 		align-items: center;
 		background-color: var(--color-back);
+		position: relative;
+	}
+	#right_bar .panel_container.topmost_panel .panel_tab_bar:not(.single_tab)::before {
+		content: "";
+		position: absolute;
+		left: -10px;
+		top: 0;
+		width: 10px;
+		height: 10px;
+		background-color: var(--color-back);
+		pointer-events: none;
 	}
 	.panel_tab_bar.single_tab {
 		background-color: var(--color-ui);


### PR DESCRIPTION
Suggested plugin rows were showing scrollbars even when they were not overflowing/scrollable

Fixes the dialog sidebar background colour not showing under dialog handle bottom left corner

Fixes the panel tab text alignment so the text is properly aligned in the tabs.
Also tweaks the panel tab padding and tab bar sizing to improve the height of the tabs and make them more uniform

Fixes the background colour at the corner of the top most group of panels in the right bar. The top left corner underneath the main viewport used to not match the tab bar background colour. This fixes that.