### PR TITLE
✨ Add `buffer` & `constants` to SAFE_APIS.

### DIFF
--- a/js/native_apis.ts
+++ b/js/native_apis.ts
@@ -39,7 +39,8 @@ const SAFE_APIS = [
 	'url',
 	'string_decoder',
 	'querystring',
-	'constants'
+	'constants',
+	'buffer'
 ];
 const REQUESTABLE_APIS = [
 	'fs',


### PR DESCRIPTION
- `buffer`: https://nodejs.org/api/buffer.html - Extremely powerful API for handling binary data. Basically everything that does anything with files or web requests uses this, but *most* of them use the global `Buffer`. However, there are some parts of the API not accessible through that global, and many older modules still import it.
- `constants`: https://github.com/nodejs/node-v0.x-archive/blob/master/lib/constants.js - Exports `process.binding('constants')`, used by a lot of popular node modules on npm, including `graceful-fs` and `polyfills`. Technically deprecated since each module exports a `.constants` since node v6.3.0, but hasn't been fully removed from the ecosystem.