### PR TITLE
✨ Upgraded version comparison tooling

### DIFF
--- a/js/api.ts
+++ b/js/api.ts
@@ -2,7 +2,7 @@ import { FormElementOptions } from "./interface/form";
 import { ModelFormat } from "./io/format";
 import { Prop } from "./misc";
 import { EventSystem } from "./util/event_system";
-import { compareVersions } from "./util/util";
+import versionUtil from './util/versionUtil';
 import { Filesystem } from "./file_system";
 import { MessageBoxOptions } from "./interface/dialog";
 import { currentwindow, shell, SystemInfo } from "./native_apis";
@@ -72,10 +72,10 @@ export const Blockbench = {
 		}
 	},
 	isNewerThan(version: string): boolean {
-		return compareVersions(Blockbench.version, version);
+		return versionUtil.compare(Blockbench.version, '>', version);
 	},
 	isOlderThan(version: string): boolean {
-		return compareVersions(version, Blockbench.version);
+		return versionUtil.compare(Blockbench.version, '<', version);
 	},
 	registerEdit() {
 		console.warn('Blockbench.registerEdit is outdated. Please use Undo.initEdit and Undo.finishEdit')
@@ -358,7 +358,7 @@ export const Blockbench = {
 	},
 	// Update
 	onUpdateTo(version, callback) {
-		if (LastVersion && compareVersions(version, LastVersion) && !Blockbench.isOlderThan(version)) {
+		if (LastVersion && versionUtil.compare(version, '>', LastVersion) && !Blockbench.isOlderThan(version)) {
 			callback(LastVersion);
 		}
 	},

--- a/js/interface/about.js
+++ b/js/interface/about.js
@@ -1,3 +1,5 @@
+import versionUtil from '../util/versionUtil'
+
 BARS.defineActions(() => {
 	new Action('about_window', {
 		name: tl('dialog.settings.about') + '...',
@@ -14,14 +16,18 @@ BARS.defineActions(() => {
 				cache: false,
 				type: 'GET',
 				success(release) {
-					let v = release.tag_name.replace(/^v/, '');
-					let version_string = Blockbench.version.replace('-beta.', ' Beta ')
-					if (compareVersions(v, Blockbench.version)) {
-						data.version_label = `${version_string} (${tl('about.version.update_available', [v])})`;
-					} else if (compareVersions(Blockbench.version, v)) {
-						data.version_label = `${version_string} (Pre-release)`;
-					} else {
-						data.version_label = `${version_string} (${tl('about.version.up_to_date')}😄)`;
+					let releaseVersion = release.tag_name.replace(/^v/, '');
+					let displayReleaseVersion = versionUtil.format(releaseVersion);
+					switch (versionUtil.compare(Blockbench.version, releaseVersion)) {
+						case 1:
+							data.version_label = `${displayReleaseVersion} (Pre-release)`;
+							break;
+						case 0:
+							data.version_label = `${displayReleaseVersion} (${tl('about.version.up_to_date')}😄)`;
+							break;
+						case -1:
+							data.version_label = `${displayReleaseVersion} (${tl('about.version.update_available', [releaseVersion])})`;
+							break;
 					}
 				},
 				error(err) {}

--- a/js/interface/start_screen.js
+++ b/js/interface/start_screen.js
@@ -1,6 +1,7 @@
 import { Filesystem } from "../file_system";
 import { documentReady } from "../misc";
 import { app, fs } from "../native_apis";
+import versionUtil from '../util/versionUtil';
 
 export const StartScreen = {
 	loaders: {},
@@ -727,8 +728,8 @@ ModelLoader.loaders = {};
 				if (typeof data.psa.version == 'string') {
 					if (data.psa.version.includes('-')) {
 						limits = data.psa.version.split('-');
-						if (limits[0] && compareVersions(limits[0], Blockbench.version)) return;
-						if (limits[1] && compareVersions(Blockbench.version, limits[1])) return;
+						if (limits[0] && versionUtil.compare(Blockbench.version, '<', limits[0])) return;
+						if (limits[1] && versionUtil.compare(Blockbench.version, '>', limits[1])) return;
 					} else {
 						if (data.psa.version != Blockbench.version) return;
 					}

--- a/js/interface/themes.ts
+++ b/js/interface/themes.ts
@@ -1,7 +1,7 @@
 import DarkTheme from '../../themes/dark.bbtheme'
 import LightTheme from '../../themes/light.bbtheme'
 import ContrastTheme from '../../themes/contrast.bbtheme'
-import { compareVersions, patchedAtob } from '../util/util'
+import { patchedAtob } from '../util/util'
 import { Dialog } from './dialog'
 import { settings, Settings } from './settings'
 import tinycolor from 'tinycolor2'
@@ -10,6 +10,7 @@ import { Blockbench } from '../api'
 import { InputFormConfig } from './form'
 import { Filesystem } from '../file_system'
 import { fs } from '../native_apis'
+import versionUtil from '../util/versionUtil'
 
 type ThemeSource = 'built_in' | 'file' | 'repository' | 'custom';
 type ThemeData = {
@@ -855,7 +856,7 @@ export function loadThemes() {
 				if (!text_content) return;
 				let theme = new CustomTheme().parseBBTheme(text_content);
 
-				if ((theme.version && !stored_theme.version) || (theme.version && stored_theme.version && compareVersions(theme.version, stored_theme.version))) {
+				if ((theme.version && !stored_theme.version) || (theme.version && stored_theme.version && versionUtil.compare(theme.version, '>', stored_theme.version))) {
 					// Update theme
 					stored_theme.extend(theme);
 					stored_theme.source = 'repository';

--- a/js/io/formats/bbmodel.js
+++ b/js/io/formats/bbmodel.js
@@ -1,7 +1,7 @@
 import { invertMolang } from '../../util/molang';
-import { compareVersions } from '../../util/util';
 import LZUTF8 from '../../lib/lzutf8'
 import { fs } from '../../native_apis';
+import versionUtil from '../../util/versionUtil';
 
 const FORMATV = '5.0';
 
@@ -16,7 +16,7 @@ function processHeader(model) {
 	if (!model.meta.format_version) {
 		model.meta.format_version = model.meta.format;
 	}
-	if (compareVersions(model.meta.format_version, FORMATV)) {
+	if (versionUtil.compare(model.meta.format_version, '>', FORMATV)) {
 		Blockbench.showMessageBox({
 			translateKey: 'outdated_client',
 			icon: 'error',
@@ -39,7 +39,7 @@ function processCompatibility(model) {
 	}
 	if (model.geometry_name) model.model_identifier = model.geometry_name;
 
-	if (model.elements && model.meta.box_uv && compareVersions('4.5', model.meta.format_version)) {
+	if (model.elements && model.meta.box_uv && versionUtil.compare(model.meta.format_version, '<=', '4.5')) {
 		model.elements.forEach(element => {
 			if (element.shade === false) {
 				element.mirror_uv = true;
@@ -48,7 +48,7 @@ function processCompatibility(model) {
 	}
 
 	if (model.outliner) {
-		if (compareVersions('3.2', model.meta.format_version)) {
+		if (versionUtil.compare(model.meta.format_version, '<=', '3.2')) {
 			//Fix Z-axis inversion pre 3.2
 			function iterate(list) {
 				for (var child of list) {
@@ -62,13 +62,13 @@ function processCompatibility(model) {
 		}
 	}
 	if (model.textures) {
-		if (isApp && compareVersions('4.10', model.meta.format_version)) {
+		if (isApp && versionUtil.compare(model.meta.format_version, '<=', '4.10')) {
 			for (let texture of model.textures) {
 				if (texture.relative_path) texture.relative_path = PathModule.join('/', texture.relative_path);
 			}
 		}
 	}
-	if (model.animations && compareVersions('5.0', model.meta.format_version)) {
+	if (model.animations && versionUtil.compare(model.meta.format_version, '<=', '5.0')) {
 		for (let anim of model.animations) {
 			for (let uuid in anim.animators) {
 				let animator = anim.animators[uuid]

--- a/js/io/formats/bedrock.js
+++ b/js/io/formats/bedrock.js
@@ -1,5 +1,6 @@
 import { findExistingFile } from "../../desktop";
 import { currentwindow, dialog, fs } from "../../native_apis";
+import versionUtil from '../../util/versionUtil'
 
 if (isApp) {
 window.BedrockEntityManager = class BedrockEntityManager {
@@ -1160,7 +1161,7 @@ var codec = new Codec('bedrock', {
 		type: 'json',
 		extensions: ['json'],
 		condition(model) {
-			return model.format_version && !compareVersions('1.12.0', model.format_version)
+			return model.format_version && versionUtil.compare(model.format_version, '<=', '1.12.0');
 		}
 	},
 	load(model, file, args = {}) {
@@ -1304,7 +1305,7 @@ var codec = new Codec('bedrock', {
 		}
 		if (data && index !== undefined) {
 
-			if (!data.format_version || compareVersions(getFormatVersion(), data.format_version)) {
+			if (!data.format_version || versionUtil.compare(data.format_version, '<=', getFormatVersion())) {
 				data.format_version = getFormatVersion();
 			}
 

--- a/js/io/formats/bedrock_old.js
+++ b/js/io/formats/bedrock_old.js
@@ -133,7 +133,7 @@ var codec = new Codec('bedrock_old', {
 		type: 'json',
 		extensions: ['json'],
 		condition(model) {
-			return (model.format_version && compareVersions('1.12.0', model.format_version)) ||
+			return (model.format_version && versions.compare(model.format_version, '<=', '1.12.0')) ||
 				Object.keys(model).find(s => s.match(/^geometry\./));
 		}
 	},

--- a/js/plugin_loader.ts
+++ b/js/plugin_loader.ts
@@ -9,6 +9,7 @@ import { getDateDisplay } from "./util/util";
 import { Filesystem } from "./file_system";
 import { app, fs, getPluginPermissions, getPluginScopedRequire, https, revokePluginPermissions } from "./native_apis";
 import { Panels } from "./interface/panels";
+import versionUtil from './util/versionUtil'
 
 
 export const Plugins = {
@@ -295,7 +296,7 @@ export class Plugin {
 		if (data.dependencies instanceof Array) this.dependencies.safePush(...data.dependencies);
 
 		if (data.new_repository_format) this.new_repository_format = true;
-		if (this.min_version != '' && !compareVersions('4.8.0', this.min_version)) {
+		if (this.min_version != '' && versionUtil.compare(this.min_version, '<=', '4.8.0')) {
 			this.new_repository_format = true;
 		}
 		if (typeof data.contributes == 'object') {
@@ -1097,7 +1098,7 @@ export async function loadInstalledPlugins() {
 					if (installation.disabled) plugin.disabled = true;
 					
 					if (isApp && (
-						(installation.version && plugin.version && !compareVersions(plugin.version, installation.version)) ||
+						(installation.version && plugin.version && versionUtil.compare(plugin.version, '<=', installation.version)) ||
 						Blockbench.isOlderThan(plugin.min_version)
 					)) {
 						// Get from file

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -1,34 +1,7 @@
 import './molang'
 
 //Blockbench
-/**
- * Compare two versions
- * @param {string} version1 
- * @param {string} version2 
- * @returns Whether version1 is higher/newer than version2
- */
-export function compareVersions(version1, version2) {
-	var arr1 = version1.split(/[.-]/);
-	var arr2 = version2.split(/[.-]/);
-	var i = 0;
-	var num1 = 0;
-	var num2 = 0;
-	while (i < Math.max(arr1.length, arr2.length)) {
-		num1 = arr1[i];
-		num2 = arr2[i];
-		if (num1 == 'beta') num1 = -1;
-		if (num2 == 'beta') num2 = -1;
-		num1 = parseInt(num1) || 0;
-		num2 = parseInt(num2) || 0;
-		if (num1 > num2) {
-			return true;
-		} else if (num1 < num2) {
-			return false
-		}
-		i++;
-	}
-	return false;
-}
+
 /**
  * 
  * @param {*} condition Input condition. Can be undefined, a boolean, a function or a condition object
@@ -746,7 +719,6 @@ Object.assign(window, {
 	Condition,
 	Objector,
 	Merge,
-	compareVersions,
 	pureMarked,
 	convertTouchEvent,
 	addEventListeners,

--- a/js/util/versionUtil.ts
+++ b/js/util/versionUtil.ts
@@ -1,0 +1,122 @@
+const VERSION_REGEX = /^(?<version>[\d.]+)(?:-beta\.(?<beta>[\d\.]+))?$/
+
+interface ParsedVersion {
+	string: string
+	version: number[]
+	beta?: number[]
+}
+
+type Operator = '<=' | '==' | '>=' | '>' | '<'
+
+function parse(versionString: string): ParsedVersion {
+	const match = versionString.match(VERSION_REGEX)
+
+	if (!match) {
+		throw new Error(
+			`Invalid version format '${versionString}'.` +
+				"Expected a list of dot-separated numbers, optionally followed by '-beta.' " +
+				"and another list of dot-separated numbers. E.g. '1.2.3' or '1.2.3-beta.4'"
+		)
+	}
+
+	const { version, beta } = match.groups
+	return {
+		string: versionString,
+		version: version.split('.').map(v => parseInt(v)),
+		beta: beta ? beta.split('.').map(v => parseInt(v)) : undefined,
+	}
+}
+
+/**
+ * Compare two version strings.
+ * @returns 0 if equal, -1 if versionA < versionB, 1 if versionA > versionB
+ */
+function compare(versionA: string, versionB: string): number
+/**
+ * Compare two version strings with an operator.
+ * @returns true if the comparison is true, false otherwise
+ */
+function compare(versionA: string, operator: Operator, versionB: string): boolean
+function compare(versionA: string, operator?: Operator, versionB?: string): boolean | number {
+	// If only two arguments are provided, treat the second as versionB and return the comparison result.
+	if (versionB === undefined) {
+		versionB = operator
+		operator = undefined
+	}
+
+	let result = 0
+
+	if (versionA !== versionB) {
+		const parsedA = parse(versionA)
+		const parsedB = parse(versionB)
+
+		const maxLength = Math.max(parsedA.version.length, parsedB.version.length)
+		for (let i = 0; i < maxLength; i++) {
+			const a = parsedA.version.at(i) ?? 0
+			const b = parsedB.version.at(i) ?? 0
+
+			if (a > b) {
+				result = 1
+				break
+			}
+
+			if (a < b) {
+				result = -1
+				break
+			}
+		}
+
+		// If the main versions are equal, compare beta versions.
+		if (result === 0) {
+			if (parsedA.beta && !parsedB.beta) {
+				result = 1
+			} else if (!parsedA.beta && parsedB.beta) {
+				result = -1
+			} else if (parsedA.beta && parsedB.beta) {
+				result = compare(parsedA.beta.join('.'), parsedB.beta.join('.'))
+			}
+		}
+	}
+
+	switch (operator) {
+		case '==':
+			return result === 0
+		case '<=':
+			return result <= 0
+		case '>=':
+			return result >= 0
+		case '<':
+			return result === -1
+		case '>':
+			return result === 1
+		// No comparison argument was provided, just return the comparison result
+		case undefined:
+			return result
+		default:
+			throw new Error(
+				`Invalid version comparison operator '${operator}'. Expected one of '<=', '==', '>=', '>', '<'.`
+			)
+	}
+}
+
+function format(version: string): string {
+	return version.replace('-beta.', ' Beta ')
+}
+
+// Backwards compatability
+window.compareVersions = (versionA: string, versionB: string) => compare(versionA, '>', versionB)
+
+const versionUtil = {
+	compare,
+	parse,
+	format,
+}
+
+declare global {
+	interface Window {
+		versionUtil: typeof versionUtil
+	}
+}
+window.versionUtil = versionUtil
+
+export default versionUtil

--- a/types/custom/blockbench.d.ts
+++ b/types/custom/blockbench.d.ts
@@ -44,6 +44,7 @@
 /// <reference types="./canvas_frame" />
 /// <reference types="./io" />
 /// <reference types="./native_apis" />
+/// <reference types="./util/versionUtil" />
 
 /**
  * Provides access to global Javascript/DOM variables that are overwritten by Blockbench's own variables

--- a/types/custom/util.d.ts
+++ b/types/custom/util.d.ts
@@ -67,7 +67,10 @@ declare function removeEventListeners(
 	option?: any
 ): void
 
-declare function compareVersions(string1: any, string2: any): boolean
+/**
+ * @deprecated Use {@link versionUtil.compare} instead.
+ */
+declare function compareVersions(versionA: any, versionB: any): boolean
 declare function convertTouchEvent(event: TouchEvent | MouseEvent): MouseEvent
 declare function guid(): string
 declare function isUUID(s: any): any

--- a/types/custom/util/versionUtil.d.ts
+++ b/types/custom/util/versionUtil.d.ts
@@ -1,0 +1,32 @@
+interface ParsedVersion {
+	string: string
+	version: number[]
+	beta?: number[]
+}
+
+type Operator = '<=' | '==' | '>=' | '>' | '<'
+
+declare namespace versionUtil {
+	function parse(versionString: string): ParsedVersion
+
+	/**
+	 * Compare two version strings.
+	 * @returns 0 if equal, -1 if versionA < versionB, 1 if versionA > versionB
+	 */
+	function compare(versionA: string, versionB: string): number
+	/**
+	 * Compare two version strings with an operator.
+	 * @returns true if the comparison is true, false otherwise
+	 */
+	function compare(versionA: string, operator: Operator, versionB: string): boolean
+
+	/**
+	 * Format a version string for display.
+	 * E.g. "4.8.0-beta.3" becomes "4.8.0 Beta 3"
+	 */
+	function format(version: string): string
+}
+
+declare interface Window {
+	versionUtil: typeof versionUtil
+}


### PR DESCRIPTION
# Why change `compareVersions`?
To make code that compares versions easier to understand at a glance, and to provide more comparison operations for versions.

Currently, you can perform several different operations by twisting the input and output of the `compareVersions` function, however, these inversions and argument swaps tend to make the code trickier to read, and more complex.
```ts
compareVersions(versionA, versionB) // A > B
!compareVersions(versionB, versionA) // A >= B
compareVersions(versionB, versionA) // A < B
!compareVersions(versionA, versionB) // A <= B
// Checking for equality is useful in cases where the versions strings don't match, but the versions do. e.g. `1.0.0.0` == `1.0`.
!(compareVersions(versionA, versionB) || compareVersions(versionB, versionA)) // A == B
```

So I thought I'd give a shot at a replacement that implements these operations natively in an easy-to-read format, while also cleaning up the implementation a bit.

## `versionUtil.compare(versionA, operator, versionB)`
Allows comparing versions using operators, making version comparisons easier to read and understand at a glance.
```ts
versionUtil.compare(versionA, '>' versionB)
versionUtil.compare(versionA, '>=' versionB)
versionUtil.compare(versionA, '<' versionB)
versionUtil.compare(versionA, '<=' versionB)
versionUtil.compare(versionA, '==' versionB)
```

## `versionUtil.compare(versionA, versionB)`
When called with only two arguments, returns a number indicating whether versionA is larger, smaller, or equal to versionB.
```ts
versionUtil.compare('2.0.0', '1.0.0') // 1
versionUtil.compare('1.0.0', '1.0.0') // 0
versionUtil.compare('1.0.0', '2.0.0') // -1
```

## Backwards compatibility
The global `compareVersions` function has been replaced with a call to `versionUtil.compare` that provides the same functionality as the original for backwards compatibility.
```ts
window.compareVersions = (versionA: string, versionB: string) => compare(versionA, '>', versionB)
```

## `versionUtil.parse`
Parses a version string and returns it's parts
```ts
versionUtil.parse('1.0.0') // { version: [1, 0, 0] }
versionUtil.parse('1.0.0-beta.2') // { version: [1, 0, 0], beta: [2] }
versionUtil.parse('1.2.3-beta.2.0') // { version: [1, 2, 3], beta: [2, 0] }
```

## `versionUtil.format`
Formats a version string for UI use.
```ts
versionUtil.format('1.3.0-beta.2') // 1.3.0 Beta 2
```