### PR TITLE
🩹 Fix collection item text overflow

### DIFF
--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -2171,7 +2171,6 @@
 		height: 27px;
 		padding: 0 7px;
 		margin: 2px;
-		max-width: 165px;
 		min-width: 149px;
 	}
 	#collection_properties_vue > ul > li.selected {


### PR DESCRIPTION
Before:
<img width="564" height="322" alt="image" src="https://github.com/user-attachments/assets/abf66c97-7aad-4109-9a14-0916b167830e" />

After:
<img width="725" height="312" alt="image" src="https://github.com/user-attachments/assets/802c9174-b294-456d-bc91-bf18e54c449b" />

I considered clipping the text instead of expanding the element, but I think it's better to be able to see the whole name of each cube.