### PR TITLE
adding a keybind to the blender bbkeymap

### DIFF
--- a/keymaps/blender.bbkeymap
+++ b/keymaps/blender.bbkeymap
@@ -66,7 +66,7 @@
 		"collapse_groups": null,
 		"unfold_groups": null,
 		"edit_bedrock_binding": null,
-		"add_mesh": null,
+		"add_mesh": {"key": 65, "shift": true},
 		"selection_mode": null,
 		"create_face": {"key": 70},
 		"convert_to_mesh": null,


### PR DESCRIPTION
I have changed line 69 of blender.bbkeymaps from null to {"key": 65, "shift": true}