### PR TITLE
Normalize macOS Delete code (8) to the 46 which Windows/Unix uses

### DIFF
--- a/js/interface/keyboard.js
+++ b/js/interface/keyboard.js
@@ -499,7 +499,12 @@ addEventListeners(document, 'keydown mousedown', function(e) {
 	if (Keybinds.recording || e.which < 4) return;
 	//Shift
 
-	
+	// Normalize Backspace/Delete key (8) to Delete keycode (46) when not in text input
+	// On macOS, the Delete key above Return sends keycode 8
+	if (e.which === 8 && !getFocusedTextInput()) {
+		Object.defineProperty(e, 'which', {value: 46, writable: false, configurable: true});
+	}
+
 	let modifiers_changed = Pressing.shift != e.shiftKey || Pressing.alt != e.altKey || Pressing.ctrl != e.ctrlKey;
 	let before = modifiers_changed && {shift: Pressing.shift, alt: Pressing.alt, ctrl: Pressing.ctrl};
 	Pressing.shift = e.shiftKey;


### PR DESCRIPTION
It's a small thing, but on a mac laptop, the delete button sends keycode 8. But all the delete shortcuts are tied to 46.

Rather than adjust the shortcuts based on whether it is mac or windows (easy enough for desktop, but harder for the webapp), I just normalize every keycode 8 into 46, because there are no shortcuts bound to 8.

[summary of the weird macOS/windows keycode issue](https://chatgpt.com/share/6903a5d7-a088-8008-b29d-1b2c1532d37c).

Without this PR, the workaround is that whenever a shortcut says `Delete`, it is actually `Fn+Delete`.