### PR TITLE
fix(optimize_animation): value check based on channel type

### DIFF
--- a/js/animations/animation.js
+++ b/js/animations/animation.js
@@ -1666,10 +1666,11 @@ BARS.defineActions(function() {
 						if (!animator[channel]?.length) continue;
 						if (!animator.channels[channel].transform) continue;
 						let first = animator[channel][0];
+						let expected = +(channel === "scale");
 						// todo: add data points
 						if (animator[channel].length == 1 && first.data_points.length == 1 && (response.selection != 'selected_keyframes' || first.selected)) {
 							let value = first.getArray();
-							if (!value[0] && !value[1] && !value[2]) {
+							if (value.allAre(v => v === expected)) {
 								first.remove();
 								continue;
 							}
@@ -1733,7 +1734,7 @@ BARS.defineActions(function() {
 									}
 								}
 							} else if (!prev && !next) {
-								if (d_kf.allAre(val => !val)) {
+								if (d_kf.allAre(val => val === expected)) {
 									remove = true;
 								} else {
 									kf.time = 0;


### PR DESCRIPTION
Seems like optimize animation isn't working as intended for `scale` channel. Expected values should be their default values, `1` for `scale` while the rest are `0` (`position`, `rotation`).

Minimal reproducible example:
[model.zip](https://github.com/user-attachments/files/23350478/model.zip)
1. Load attached model
2. Go to animate tab
3. Run optimize animation on `animation.model.new`

Expected behavior:
Keyframes on scale channel shouldn't be removed.

https://github.com/user-attachments/assets/558031dd-5612-4e18-9b47-da9d1707b279
