### PR TITLE
correct BarSelect.value types to match option keys

### DIFF
--- a/types/custom/action.d.ts
+++ b/types/custom/action.d.ts
@@ -530,7 +530,7 @@ declare global {
 		constructor(id: string, options: BarSelectOptions<T>)
 		open(event: Event): void
 		trigger(event: Event): boolean | undefined
-		change(value: T, event: Event): this
+		change(value: string, event: Event): this
 		getNameFor(key: string): string
 		set(key: string): this
 		get(): string


### PR DESCRIPTION
BarSelectM<T> and BarSelectOptions<T>'s attribute `value` stores the currently selected / default key in the options attribute, which is of type Record<string, T>.
This PR just changes the typing of the attributes in the BarSelectOptions class and the BarSelect class to reflect their usage.

**currently:**
```typescript
let barItem1 = new BarSelect<number>('select_id', {
  options: {
      "a": 1,
      "b": 2
  },
 //linter error: "The expected type comes from property 'value' which is declared here on type 'BarSelectOptions<number>'"
      value: "a",   
  });
```
This previously gave a linter error but compiles and has no runtime errors, and conversely, `value: 1` showed no linter error yet raised an error at runtime

Let me know if I'm wrong or I've made a mistake here, as I've only recently started learning plugins for blockbench,
Thanks!