### PR TITLE
🩹 Fix BBPlugin typing

### DIFF
--- a/js/plugin_loader.ts
+++ b/js/plugin_loader.ts
@@ -1913,7 +1913,9 @@ BARS.defineActions(function() {
 	})
 })
 
-
+declare global {
+	const BBPlugin: typeof Plugin;
+}
 Object.assign(window, {
 	Plugins,
 	Plugin,


### PR DESCRIPTION
Declares `BBPlugin` as a global. in both generated, and internal types.

NOTE: This should be done for any types that are assigned to `window`.