### PR TITLE
⚙️ Auto-publish blockbench-types@next when changes are made to the `next` branch

### DIFF
--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -20,5 +20,3 @@ jobs:
       - run: npm run generate-types
       - run: (cd ./types; version=$(npm view blockbench-types@next version); echo $(echo $version | sed 's/[0-9]*$//')$(echo $version | cut -d '-' -f3 | expr $(sed 's/[^0-9]//g') + 1))
       - run: npm run publish-types --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
When publishing, this script gets the latest released `next` version from npm and increments the last number in it by 1.