### PR TITLE
Fix macOS Rectangle Select Always Extends Selection

### DIFF
--- a/js/preview/preview.js
+++ b/js/preview/preview.js
@@ -1455,7 +1455,7 @@ export class Preview {
 		let rect_start = [c.ax, c.ay];
 		let rect_end = [c.bx, c.by];
 		let extend_selection = (event.shiftKey || Pressing.overrides.shift) ||
-				((event.ctrlOrCmd || Pressing.overrides.ctrl) && !Keybinds.extra.preview_area_select.keybind.ctrl)
+				((event.ctrlOrCmd || Pressing.overrides.ctrl) && !Keybinds.extra.preview_area_select.keybind.ctrl && !Keybinds.extra.preview_area_select.keybind.meta)
 		let selection_mode = BarItems.selection_mode.value;
 		let spline_selection_mode = BarItems.spline_selection_mode.value;
 


### PR DESCRIPTION
macOS Rectangle Select Always Extends Selection

fixes #3282 

## Summary

Fixed a bug where rectangle select on macOS always extended the existing selection instead of replacing it, making it impossible to start a fresh selection with Cmd+drag.

## Bug Description

On macOS, using Cmd+drag to rectangle select in the 3D preview always added to the existing selection. Users could not replace their selection by dragging a new rectangle. Every rectangle select operation was additive.

Windows and web platforms were unaffected; Ctrl+drag correctly started a new selection on those platforms.

## Root Cause

The `extend_selection` logic in `js/preview/preview.js` checked whether `ctrlOrCmd` was pressed and whether the keybind's `.ctrl` property was set. The intent was to avoid treating the modifier as "extend selection" when that same modifier is already used to activate the tool.

However, Blockbench's `Keybind` constructor (`js/interface/keybinding.js`) automatically converts `.ctrl` to `.meta` on macOS:

```javascript
if (isApp && Blockbench.platform == 'darwin' && keys.ctrl && !keys.meta) {
    keys.meta = true;
    keys.ctrl = undefined;
}
```

The `preview_area_select` keybind is defined with `ctrl: true`, which becomes `meta: true` on macOS. The original check only tested `!keybind.ctrl`, which evaluated to `true` on macOS (since `.ctrl` was `undefined`), causing `extend_selection` to always be `true`.

## Fix

**File:** `js/preview/preview.js`, line 1458

Added a check for the `.meta` property alongside the existing `.ctrl` check:

```diff
 let extend_selection = (event.shiftKey || Pressing.overrides.shift) ||
-    ((event.ctrlOrCmd || Pressing.overrides.ctrl) && !Keybinds.extra.preview_area_select.keybind.ctrl)
+    ((event.ctrlOrCmd || Pressing.overrides.ctrl) && !Keybinds.extra.preview_area_select.keybind.ctrl && !Keybinds.extra.preview_area_select.keybind.meta)
```
