### PR TITLE
🐛 Fix plugin icon rendering mode

### DIFF
--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -1540,6 +1540,7 @@
 	.plugin_icon_area img {
 		border-radius: 8px;
 		pointer-events: none;
+		image-rendering: auto;
 	}
 	#plugin_list > li * {
 		cursor: inherit;


### PR DESCRIPTION
Added `image-rendering: auto;` to the icon element's properties to improve image quality.

Before:
<img width="573" height="224" alt="image" src="https://github.com/user-attachments/assets/ea450c33-f80d-4da4-91ab-4914a7e1b8a8" />

After:
<img width="560" height="222" alt="image" src="https://github.com/user-attachments/assets/b7b3e07a-c90e-41b0-bcfe-32a7756c1408" />
