### PR TITLE
Exclude meshes without selected vertices from transforms and selection center in vertex/edge mode

### DIFF
--- a/js/modeling/transform.js
+++ b/js/modeling/transform.js
@@ -17,6 +17,12 @@ export function getSelectionCenter(all = false) {
 	}
 	elements.forEach(element => {
 		if (element instanceof Group && !Format.bone_rig) return;
+		// In vertex/edge mode, exclude meshes with no selected vertices from center
+		if ((element instanceof Mesh || element instanceof SplineMesh) &&
+			(BarItems.selection_mode?.value === 'vertex' || BarItems.selection_mode?.value === 'edge') &&
+			!element.getSelectedVertices().length) {
+			return;
+		}
 		if (element.getWorldCenter) {
 			var pos = element.getWorldCenter();
 			min[0] = Math.min(pos.x, min[0]);	max[0] = Math.max(pos.x, max[0]);
@@ -148,6 +154,12 @@ export function moveElementsRelative(difference, index, event) { //Multiple
 //Rotate
 export function rotateSelected(axis, steps) {
 	let affected = [...Cube.selected, ...Mesh.selected, ...SplineMesh.selected];
+	// In vertex/edge selection mode, only include meshes with selected vertices
+	if (BarItems.selection_mode?.value === 'vertex' || BarItems.selection_mode?.value === 'edge') {
+		affected = affected.filter(el =>
+			!(el instanceof Mesh || el instanceof SplineMesh) || el.getSelectedVertices().length
+		);
+	}
 	if (!affected.length) return;
 	Undo.initEdit({elements: affected});
 	if (!steps) steps = 1
@@ -339,6 +351,13 @@ export function moveElementsInSpace(difference, axis) {
 
 		if (el.getTypeBehavior('movable') == false) return;
 		if (!el.getTypeBehavior('use_absolute_position') && el.parent?.selected && el.parent.getTypeBehavior('movable') && !el.parent.getTypeBehavior('use_absolute_position')) {
+			return;
+		}
+
+		// In vertex/edge selection mode, skip meshes with no selected vertices
+		if ((el instanceof Mesh || el instanceof SplineMesh) &&
+			(BarItems.selection_mode?.value === 'vertex' || BarItems.selection_mode?.value === 'edge') &&
+			!el.getSelectedVertices().length) {
 			return;
 		}
 
@@ -633,6 +652,13 @@ export function rotateOnAxis(modify, axis, slider) {
 	let space = getEditTransformSpace()
 	if (axis instanceof THREE.Vector3) space = 0;
 	things.forEach(obj => {
+		// In vertex/edge selection mode, skip meshes with no selected vertices
+		if ((obj instanceof Mesh || obj instanceof SplineMesh) &&
+			(BarItems.selection_mode?.value === 'vertex' || BarItems.selection_mode?.value === 'edge') &&
+			!obj.getSelectedVertices().length) {
+			return;
+		}
+
 		let mesh = obj.mesh;
 		if (obj instanceof Cube && !Format.bone_rig) {
 			if (obj.origin.allEqual(0)) {
@@ -979,6 +1005,13 @@ BARS.defineActions(function() {
 
 	function resizeOnAxis(modify, axis) {
 		Outliner.selected.forEach(function(obj, i) {
+			// In vertex/edge selection mode, skip meshes with no selected vertices
+			if ((obj instanceof Mesh || obj instanceof SplineMesh) &&
+				(BarItems.selection_mode?.value === 'vertex' || BarItems.selection_mode?.value === 'edge') &&
+				!obj.getSelectedVertices().length) {
+				return;
+			}
+
 			if (obj.getTypeBehavior('resizable')) {
 				let bidirectional = obj instanceof Mesh;
 				let center = (obj.from && obj.to) && Math.lerp(obj.from[axis], obj.to[axis], 0.5);

--- a/js/modeling/transform/edit_transform.js
+++ b/js/modeling/transform/edit_transform.js
@@ -285,6 +285,13 @@ new TransformerModule('edit', {
 		} else if (tool_id === 'resize_tool') {
 
 			Outliner.selected.forEach(function(obj, i) {
+				// In vertex/edge selection mode, skip meshes with no selected vertices
+				if ((obj instanceof Mesh || obj instanceof SplineMesh) &&
+					(BarItems.selection_mode?.value === 'vertex' || BarItems.selection_mode?.value === 'edge') &&
+					!obj.getSelectedVertices().length) {
+					return;
+				}
+
 				if (obj.getTypeBehavior('resizable')) {
 					let bidirectional = ((event.altKey || Pressing.overrides.alt) && BarItems.swap_tools.keybind.key != 18) !== Mesh.hasSelected();
 


### PR DESCRIPTION
**Problem:** When two meshes are selected, but vertices/edges are only selected on one of them, the other mesh still participates in Move, Rotate, and Resize operations — either by moving its entire position (global space) or all of its vertices (local space). The selection center also includes the unselected mesh, shifting the transform gizmo to an incorrect pivot.

**Fix:** In `vertex` and `edge` selection modes, Mesh and SplineMesh elements with no selected vertices are now skipped during all transform operations. The same guard is applied consistently across six locations:

| Function | File | Operation |
|---|---|---|
| `moveElementsInSpace` | `transform.js` | Move (gizmo + sliders) |
| `resizeOnAxis` | `transform.js` | Resize (sliders) |
| `onMove` (resize_tool) | `edit_transform.js` | Resize (gizmo) |
| `rotateOnAxis` | `transform.js` | Rotate (gizmo) |
| `rotateSelected` | `transform.js` | Rotate (action/keybind) |
| `getSelectionCenter` | `transform.js` | Transform gizmo pivot |
