### PR TITLE
Add "Selectable Wireframe" theme color for unselected mesh edges and vertices

### DIFF
--- a/js/interface/themes.ts
+++ b/js/interface/themes.ts
@@ -55,6 +55,7 @@ const DEFAULT_COLORS = {
 	subtle_text: '#848891',
 	grid: '#30333d',
 	wireframe: '#576f82',
+	wireframe_selectable: '#576f82',
 	checkerboard: '#14171b',
 }
 
@@ -597,6 +598,7 @@ export class CustomTheme {
 			update(gizmo_colors.g, '--color-axis-y');
 			update(gizmo_colors.b, '--color-axis-z');
 			update(gizmo_colors.grid, '--color-grid');
+			update(gizmo_colors.wireframe_selectable, '--color-wireframe_selectable');
 			update(gizmo_colors.u, '--color-axis-u'); // spline space colors
 			update(gizmo_colors.v, '--color-axis-v'); // spline space colors
 			update(gizmo_colors.w, '--color-axis-w'); // spline space colors

--- a/js/outliner/types/mesh.js
+++ b/js/outliner/types/mesh.js
@@ -1554,7 +1554,7 @@ new NodePreviewController(Mesh, {
 				if (selected_vertices.includes(key)) {
 					color = white;
 				} else {
-					color = gizmo_colors.grid;
+					color = gizmo_colors.wireframe_selectable;
 				}
 				colors.push(color.r, color.g, color.b);
 			}
@@ -1581,7 +1581,7 @@ new NodePreviewController(Mesh, {
 		if (!Modes.edit) selection_mode = 'object';
 		mesh.outline.vertex_order.forEach((key, i) => {
 			let key_b = Modes.edit && mesh.outline.vertex_order[i + ((i%2) ? -1 : 1) ];
-			let color = gizmo_colors.grid;
+			let color = gizmo_colors.wireframe_selectable;
 			let selected;
 			switch (selection_mode) {
 				case 'object': {

--- a/js/preview/preview.ts
+++ b/js/preview/preview.ts
@@ -61,6 +61,7 @@ export const gizmo_colors = {
 	g: new THREE.Color(),
 	b: new THREE.Color(),
 	grid: new THREE.Color(),
+	wireframe_selectable: new THREE.Color(),
 	solid: new THREE.Color(),
 	outline: new THREE.Color(),
 	gizmo_hover: new THREE.Color(),

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Posune vybrané prvky dozadu vzhledem k aktuálnímu úhlu kamery",
 	"layout.color.wireframe": "Drátový Rám",
 	"layout.color.wireframe.desc": "Drátový Rám - Zobrazit linky",
+	"layout.color.wireframe_selectable": "Vybratelný drátěný model",
+	"layout.color.wireframe_selectable.desc": "Nevybrané hrany a vrcholy aktivní sítě v editačním režimu",
 	"action.add_animation": "Přidat Animaci",
 	"action.add_animation.desc": "Vytvoří prázdnou animaci",
 	"action.load_animation_file": "Vložit Animaci",

--- a/lang/de.json
+++ b/lang/de.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Verschiebt die ausgewählten Elemente relativ zur Kameraperspektive nach hinten",
 	"layout.color.wireframe": "Drahtgitter",
 	"layout.color.wireframe.desc": "Drahtgitterlinien",
+	"layout.color.wireframe_selectable": "Auswählbares Drahtgitter",
+	"layout.color.wireframe_selectable.desc": "Nicht ausgewählte Kanten und Eckpunkte des aktiven Netzes im Bearbeitungsmodus",
 	"action.add_animation": "Animation hinzufügen",
 	"action.add_animation.desc": "Fügt eine neue Animation hinzu",
 	"action.load_animation_file": "Animation importieren",

--- a/lang/en.json
+++ b/lang/en.json
@@ -975,6 +975,8 @@
 	"layout.color.grid.desc": "3D preview grid",
 	"layout.color.wireframe": "Wireframe",
 	"layout.color.wireframe.desc": "Wireframe view lines",
+	"layout.color.wireframe_selectable": "Selectable Wireframe",
+	"layout.color.wireframe_selectable.desc": "Unselected edges and vertices of the active mesh in edit mode",
 	"layout.color.text": "Text",
 	"layout.color.text.desc": "Normal text",
 	"layout.color.light": "Light",

--- a/lang/es.json
+++ b/lang/es.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Mueve los cubos seleccionados hacia atrás relativo al ángulo actual de la cámara",
 	"layout.color.wireframe": "Estructura",
 	"layout.color.wireframe.desc": "Líneas de vista de la estructura",
+	"layout.color.wireframe_selectable": "Estructura seleccionable",
+	"layout.color.wireframe_selectable.desc": "Aristas y vértices no seleccionados de la malla activa en modo edición",
 	"action.add_animation": "Añadir Animación",
 	"action.add_animation.desc": "Crear Animación Vacía",
 	"action.load_animation_file": "Importar Animaciones",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Déplace les cubes sélectionnés vers l'arrière par rapport à l'angle de la caméra actuel",
 	"layout.color.wireframe": "Squelette",
 	"layout.color.wireframe.desc": "Contours de vue squelettique",
+	"layout.color.wireframe_selectable": "Squelette sélectionnable",
+	"layout.color.wireframe_selectable.desc": "Arêtes et sommets non sélectionnés du maillage actif en mode édition",
 	"action.add_animation": "Ajouter une animation",
 	"action.add_animation.desc": "Crée une animation vierge",
 	"action.load_animation_file": "Importer une animation",

--- a/lang/it.json
+++ b/lang/it.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Sposta i cubi selezionati indietro relativamente all'angolo della videocamera",
 	"layout.color.wireframe": "Wireframe",
 	"layout.color.wireframe.desc": "Linee del wireframe",
+	"layout.color.wireframe_selectable": "Wireframe selezionabile",
+	"layout.color.wireframe_selectable.desc": "Spigoli e vertici non selezionati della mesh attiva in modalità modifica",
 	"action.add_animation": "Aggiungi Animazione",
 	"action.add_animation.desc": "Crea Animazione Vuota",
 	"action.load_animation_file": "Importa Animazioni",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "選択したキューブを後方に移動します",
 	"layout.color.wireframe": "ワイヤーフレーム",
 	"layout.color.wireframe.desc": "ワイヤーフレームビュー",
+	"layout.color.wireframe_selectable": "選択可能なワイヤーフレーム",
+	"layout.color.wireframe_selectable.desc": "編集モードでのアクティブメッシュの未選択の辺と頂点",
 	"action.add_animation": "アニメーションを追加",
 	"action.add_animation.desc": "新規アニメーションを追加します",
 	"action.load_animation_file": "アニメーションを読み込み",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "선택한 큐브를 현재 카메라 각도에 대해 뒤로 이동",
 	"layout.color.wireframe": "와이어프레임",
 	"layout.color.wireframe.desc": "와이어프레임 선 보기",
+	"layout.color.wireframe_selectable": "선택 가능한 와이어프레임",
+	"layout.color.wireframe_selectable.desc": "편집 모드에서 활성 메시의 선택되지 않은 모서리 및 정점",
 	"action.add_animation": "애니메이션 추가",
 	"action.add_animation.desc": "빈 애니메이션 생성",
 	"action.load_animation_file": "애니메이션 가져오기",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Beweeg de geselecteerde kubussen naar achteren ten opzichte van de huidige camera hoek",
 	"layout.color.wireframe": "Wireframe",
 	"layout.color.wireframe.desc": "Wireframe bekijk lijnen",
+	"layout.color.wireframe_selectable": "Selecteerbare wireframe",
+	"layout.color.wireframe_selectable.desc": "Niet-geselecteerde randen en hoekpunten van de actieve mesh in bewerkingsmodus",
 	"action.add_animation": "Voeg Animatie Toe",
 	"action.add_animation.desc": "Maak een blanco animatie",
 	"action.load_animation_file": "Import Animatie",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Przesuń zaznaczone kostki do tyłu, względem aktualnego kąta kamery",
 	"layout.color.wireframe": "Szkielet",
 	"layout.color.wireframe.desc": "Widok linii szkieletów",
+	"layout.color.wireframe_selectable": "Wybieralny szkielet",
+	"layout.color.wireframe_selectable.desc": "Niezaznaczone krawędzie i wierzchołki aktywnej siatki w trybie edycji",
 	"action.add_animation": "Dodaj animację",
 	"action.add_animation.desc": "Stwórz pustą animację",
 	"action.load_animation_file": "Importuj animacje",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Mover os cubos selecionados para a trás em relação ao ângulo atual da câmera",
 	"layout.color.wireframe": "Visão de Arames",
 	"layout.color.wireframe.desc": "Linhas de visão de arames",
+	"layout.color.wireframe_selectable": "Arame selecionável",
+	"layout.color.wireframe_selectable.desc": "Arestas e vértices não selecionados da malha ativa no modo de edição",
 	"action.add_animation": "Adicionar Animação",
 	"action.add_animation.desc": "Criar uma animação em branco",
 	"action.load_animation_file": "Importar Animações",

--- a/lang/pt_br.json
+++ b/lang/pt_br.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Move os cubos selecionados para atrás em relação ao ângulo atual da câmera.",
 	"layout.color.wireframe": "Estrutura de arame",
 	"layout.color.wireframe.desc": "Linhas da estrutura de arame.",
+	"layout.color.wireframe_selectable": "Estrutura de arame selecionável",
+	"layout.color.wireframe_selectable.desc": "Arestas e vértices não selecionados da malha ativa no modo de edição",
 	"action.add_animation": "Adicionar animação",
 	"action.add_animation.desc": "Cria uma animação em branco.",
 	"action.load_animation_file": "Importar animações",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Сместить выбранные элементы назад относительно камеры",
 	"layout.color.wireframe": "Каркас",
 	"layout.color.wireframe.desc": "Линии при отображении каркаса",
+	"layout.color.wireframe_selectable": "Выделяемый каркас",
+	"layout.color.wireframe_selectable.desc": "Невыделенные рёбра и вершины активного меша в режиме редактирования",
 	"action.add_animation": "Добавление анимации",
 	"action.add_animation.desc": "Создать пустую анимацию",
 	"action.load_animation_file": "Импортирование анимаций",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Flytta de valda kuberna bakåt relativt till den nuvarande kameravinkeln",
 	"layout.color.wireframe": "Wireframe",
 	"layout.color.wireframe.desc": "Visa wireframe linjer",
+	"layout.color.wireframe_selectable": "Valbar wireframe",
+	"layout.color.wireframe_selectable.desc": "Omarkerade kanter och hörn av det aktiva nätet i redigeringsläge",
 	"action.add_animation": "Lägg till animation",
 	"action.add_animation.desc": "Skapa en tom animation",
 	"action.load_animation_file": "Importera animationer",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Seçili öğeleri mevcut kamera açısına göre geri taşıyın",
 	"layout.color.wireframe": "Tel Kafes",
 	"layout.color.wireframe.desc": "Tel kafes görünüm çizgileri",
+	"layout.color.wireframe_selectable": "Seçilebilir Tel Kafes",
+	"layout.color.wireframe_selectable.desc": "Düzenleme modunda aktif ağın seçili olmayan kenarları ve köşeleri",
 	"action.add_animation": "Animasyon Ekle",
 	"action.add_animation.desc": "Boş bir animasyon oluşturun",
 	"action.load_animation_file": "Animasyonları İçe Aktar",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Перемістити виділені елементи назад відносно поточного ракурсу камери",
 	"layout.color.wireframe": "Каркас",
 	"layout.color.wireframe.desc": "Лінії каркасного виду",
+	"layout.color.wireframe_selectable": "Виділюваний каркас",
+	"layout.color.wireframe_selectable.desc": "Невиділені ребра та вершини активної сітки в режимі редагування",
 	"action.add_animation": "Додати анімацію",
 	"action.add_animation.desc": "Створити анімацію",
 	"action.load_animation_file": "Імпортувати анімації",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "Di chuyển các phần tử đã chọn trở lại so với góc camera hiện tại",
 	"layout.color.wireframe": "Khung xương",
 	"layout.color.wireframe.desc": "Xem các dòng khung xương",
+	"layout.color.wireframe_selectable": "Khung xương có thể chọn",
+	"layout.color.wireframe_selectable.desc": "Các cạnh và đỉnh không được chọn của lưới đang hoạt động trong chế độ chỉnh sửa",
 	"action.add_animation": "Thêm hoạt ảnh",
 	"action.add_animation.desc": "Tạo một hoạt ảnh trống",
 	"action.load_animation_file": "Nhập hoạt ảnh",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "相对于当前视角向后移动所选块",
 	"layout.color.wireframe": "线框",
 	"layout.color.wireframe.desc": "线框模式中的线",
+	"layout.color.wireframe_selectable": "可选择的线框",
+	"layout.color.wireframe_selectable.desc": "编辑模式下活动网格的未选中边和顶点",
 	"action.add_animation": "添加动画",
 	"action.add_animation.desc": "创建一个空白动画",
 	"action.load_animation_file": "导入动画文件",

--- a/lang/zh_tw.json
+++ b/lang/zh_tw.json
@@ -548,6 +548,8 @@
 	"action.move_back.desc": "將選取的立方體按攝影機視角往後移動",
 	"layout.color.wireframe": "線框",
 	"layout.color.wireframe.desc": "線框視圖的線條",
+	"layout.color.wireframe_selectable": "可選擇的線框",
+	"layout.color.wireframe_selectable.desc": "編輯模式下活動網格的未選中邊和頂點",
 	"action.add_animation": "添加動畫",
 	"action.add_animation.desc": "創建一個空白動畫",
 	"action.load_animation_file": "匯入動畫",


### PR DESCRIPTION
**Problem:** In the Theme → Color Scheme dialog, the `Grid` color controls both the floor grid AND the unselected edges/vertices of the active mesh in edge/vertex selection mode. Making the grid brighter to see edges on textured faces makes the floor grid distractingly bright. There is no way to set these independently.

The existing `Wireframe` color only affects the wireframe view mode (`Canvas.wireframeMaterial`) — not the selectable mesh edges.

**Fix:** A new theme color `Selectable Wireframe` (`wireframe_selectable`) is added, separate from both `Grid` and `Wireframe`. It controls the color of unselected edges and vertices on the active mesh in edit mode.

| Color | Default | Controls |
|---|---|---|
| `Grid` | `#30333d` | Floor grid only |
| `Wireframe` | `#576f82` | Wireframe view mode (unchanged) |
| **`Selectable Wireframe`** ✨ | `#576f82` | **Unselected edges & vertices of the active mesh** |
