### PR TITLE
Fix linux paths for Aseprite, PixiEditor, Photoshop, and GIMP

### DIFF
--- a/js/desktop.js
+++ b/js/desktop.js
@@ -326,7 +326,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\Aseprite\\Aseprite.exe',
 			darwin: '/Applications/Aseprite.app',
-			linux: '/usr/share/applications//aseprite.desktop',
+			linux: '/usr/share/applications/aseprite.desktop',
 		}
 	},
 	pixieditor: {
@@ -334,7 +334,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\PixiEditor\\PixiEditor.exe',
 			darwin: '/Applications/PixiEditor.app',
-			linux: '/usr/share/applications//pixieditor.desktop',
+			linux: '/usr/share/applications/pixieditor.desktop',
 		}
 	},
 	ps: {
@@ -342,7 +342,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\Adobe\\Adobe Photoshop 2026\\Photoshop.exe',
 			darwin: '/Applications/Adobe Photoshop 2026/Adobe Photoshop 2026.app',
-			linux: '/usr/share/applications//photoshop.desktop'
+			linux: '/usr/share/applications/photoshop.desktop'
 		}
 	},
 	gimp: {
@@ -350,7 +350,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\GIMP 3\\bin\\gimp-3.exe',
 			darwin: '/Applications/Gimp-3.app',
-			linux: '/usr/share/applications//gimp.desktop',
+			linux: '/usr/share/applications/gimp.desktop',
 		}
 	},
 	pdn: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Blockbench",
 	"description": "Low-poly modeling and animation software",
-	"version": "5.1.3",
+	"version": "5.1.4",
 	"license": "GPL-3.0-or-later",
 	"author": {
 		"name": "JannisX11",


### PR DESCRIPTION
The Edit Externally function in Linux is broken because it ends with a // instead of a /