### PR TITLE
Fix orthographic camera clipping and raycaster for models larger than default frustum

### DIFF
--- a/js/modeling/transform/transform_gizmo.js
+++ b/js/modeling/transform/transform_gizmo.js
@@ -1531,6 +1531,12 @@ import { TransformerModule } from "./transform_modules";
 				pointerVector.set( ( x * 2 ) - 1, - ( y * 2 ) + 1 );
 				ray.setFromCamera( pointerVector, scope.camera );
 
+				// Fix for orthographic: use near plane as ray origin instead of camera plane
+				if (scope.camera && scope.camera.isOrthographicCamera) {
+					ray.ray.origin.set(pointerVector.x, pointerVector.y, -1).unproject(scope.camera);
+					ray.far = scope.camera.far - scope.camera.near;
+				}
+
 				var intersections = ray.intersectObjects( objects, true );
 				return intersections[ 0 ] ? intersections[ 0 ] : false;
 			}

--- a/js/preview/preview.ts
+++ b/js/preview/preview.ts
@@ -330,7 +330,7 @@ export class Preview {
 		this.angle = null;
 		this.camPers = new THREE.PerspectiveCamera(settings.fov.value as number, 16 / 9, settings.camera_near_plane.value as number||1, 30000);
 		// @ts-expect-error
-		this.camOrtho = new THREE.OrthographicCamera(-600,  600, -400, 400, -200, 20000);
+		this.camOrtho = new THREE.OrthographicCamera(-131072, 131072, -131072, 131072, -131072, 131072);
 		this.camOrtho.backgroundHandle = [{n: false, a: 'x'}, {n: false, a: 'y'}]
 		this.camOrtho.axis = null
 		this.camOrtho.zoom = 0.5
@@ -539,6 +539,13 @@ export class Preview {
 		this.mouse.x = ((event.clientX - canvas_offset.left) / this.width) * 2 - 1;
 		this.mouse.y = - ((event.clientY - canvas_offset.top) / this.height) * 2 + 1;
 		this.raycaster.setFromCamera( this.mouse, this.camera );
+
+		// Fix for orthographic: use near plane as ray origin instead of camera plane,
+		// so that rays can reach geometry both in front of and behind the camera.
+		if (this.isOrtho) {
+			this.raycaster.ray.origin.set(this.mouse.x, this.mouse.y, -1).unproject(this.camera);
+			this.raycaster.far = this.camOrtho.far - this.camOrtho.near;
+		}
 
 		var objects = []
 		Outliner.elements.forEach(element => {


### PR DESCRIPTION
Blockbench's orthographic camera uses a fixed near plane of `-200`, which clips geometry more than 200 units behind the camera (e.g. building tops above `Y = 512` in Top View). Combined with the raycaster placing its origin on the camera plane (`z = 0` in NDC), rays only travel forward — geometry and gizmo handles behind the camera are unreachable.

### Changes

**`js/preview/preview.ts`**
- Increase ortho near/far from `-200`/`20000` to `-131072`/`131072`
  (symmetric ±2¹⁷), covering any reasonable model size with zero
  floating-point precision cost for orthographic projection
- After `setFromCamera`, move raycaster origin to the near plane (`z = -1` in NDC) instead of the camera plane, so rays can traverse the entire frustum in both directions
- Clamp `raycaster.far` to `far - near` so the ray does not extend beyond the frustum

**`js/modeling/transform/transform_gizmo.js`**
- Apply the same raycaster fix to the gizmo hit-testing, so gizmo arrows remain draggable regardless of the selected element's position relative to the camera

### Why this approach

THREE.js r129 hardcodes the ortho raycaster origin at NDC `z = (near+far)/(near-far)`, which is always `0` with symmetric near/far — placing it on the camera plane. In most 3D editors the camera stays outside the scene, but Blockbench users frequently orbit/pan the camera *inside* the geometry. A fully symmetric frustum plus a one-line raycaster origin correction handles both cases without touching the rendering pipeline.
