### PR TITLE
Fix toolbar context menu crash with `EventPosition` type guard

### DIFF
--- a/js/interface/menu.ts
+++ b/js/interface/menu.ts
@@ -48,6 +48,14 @@ export interface CustomMenuItem {
 	click?(context?: any, event?: Event): void
 }
 export type MenuItem = CustomMenuItem | Action | BarSelect | MenuSeparator | string | ((context: any) => MenuItem)
+
+interface EventPosition { clientX: number; clientY: number }
+
+function isEventPosition(obj: unknown): obj is EventPosition {
+	const ep = obj as EventPosition;
+	return typeof ep?.clientX === 'number'
+		&& typeof ep?.clientY === 'number';
+}
 type ResolvedMenuItem = CustomMenuItem | Action | BarSelect
 type MenuParentItem = (CustomMenuItem | Action | BarSelect)
 type MenuOpenPositionAnchor = MouseEvent | HTMLElement | 'mouse';
@@ -655,7 +663,7 @@ export class Menu implements Deletable {
 		}
 		let window_height = window.innerHeight - top_gap;
 
-		if (position instanceof Event && position.clientX !== undefined) {
+		if (isEventPosition(position)) {
 			var offset_left = position.clientX
 			var offset_top  = position.clientY+1
 


### PR DESCRIPTION
`Toolbar.contextmenu()` replaces the real `MouseEvent` with a plain object `{clientX, clientY}` before passing it to `Menu.open()`. After the TypeScript conversion, `Menu.open()` was changed to check `position instanceof Event` — which a plain object fails — causing `$(position).offset()` to throw `getClientRects is not a function`.

### Changes

**`js/interface/menu.ts`**
- Add `EventPosition` interface and `isEventPosition()` type guard
- Replace `position instanceof Event` with `isEventPosition(position)`, matching the original duck-typing behavior from the JavaScript version
