### PR TITLE
Fix color picker teardown on form rebuild

### DIFF
--- a/css/panels.css
+++ b/css/panels.css
@@ -1859,7 +1859,6 @@
 	}
 	.channel_head span.timeline_animator_name {
 		padding-left: 5px;
-		pointer-events: none;
 	}
 	.animator_channel_bar .channel_head span {
 		font-size: 0.93em;

--- a/js/animations/molang.js
+++ b/js/animations/molang.js
@@ -1,4 +1,5 @@
 import { isStringNumber } from "../util/math_util"
+import { EffectAnimator } from "./timeline_animators"
 
 Animator.MolangParser.context = {}
 Animator.MolangParser.global_variables = {
@@ -237,7 +238,11 @@ new ValidatorCheck('molang_syntax', {
 			if (clear_string.match(/^[+*/.,?=&<>|]/)) {
 				issues.push('Expression starts with an invalid character')
 			}
-			if (clear_string.endsWith(';') && !clear_string.includes('return ')) {
+			if (
+				clear_string.endsWith(';') &&
+				!clear_string.includes('return ') &&
+				!(instance instanceof Keyframe && instance.animator instanceof EffectAnimator)
+			) {
 				issues.push('Complex expression with no return value. Remove the semicolon or add a return statement')
 			}
 			if (

--- a/js/desktop.js
+++ b/js/desktop.js
@@ -326,7 +326,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\Aseprite\\Aseprite.exe',
 			darwin: '/Applications/Aseprite.app',
-			linux: '/usr/share/applications//aseprite.desktop',
+			linux: '/usr/share/applications/aseprite.desktop',
 		}
 	},
 	pixieditor: {
@@ -334,7 +334,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\PixiEditor\\PixiEditor.exe',
 			darwin: '/Applications/PixiEditor.app',
-			linux: '/usr/share/applications//pixieditor.desktop',
+			linux: '/usr/share/applications/pixieditor.desktop',
 		}
 	},
 	ps: {
@@ -342,7 +342,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\Adobe\\Adobe Photoshop 2026\\Photoshop.exe',
 			darwin: '/Applications/Adobe Photoshop 2026/Adobe Photoshop 2026.app',
-			linux: '/usr/share/applications//photoshop.desktop'
+			linux: '/usr/share/applications/photoshop.desktop'
 		}
 	},
 	gimp: {
@@ -350,7 +350,7 @@ const ImageEditorPresets = {
 		paths: {
 			win32: 'C:\\Program Files\\GIMP 3\\bin\\gimp-3.exe',
 			darwin: '/Applications/Gimp-3.app',
-			linux: '/usr/share/applications//gimp.desktop',
+			linux: '/usr/share/applications/gimp.desktop',
 		}
 	},
 	pdn: {

--- a/js/interface/actions.ts
+++ b/js/interface/actions.ts
@@ -2012,6 +2012,10 @@ export class ColorPicker extends Widget {
 		// @ts-expect-error
 		this.jq.spectrum('cancel');
 	}
+	delete() {
+		this.jq.spectrum('destroy');
+		super.delete();
+	}
 	confirm() {
 		this.jq.spectrum('hide');
 	}
@@ -2069,4 +2073,3 @@ declare global {
 	const BarItems: typeof global.BarItems
 }
 Object.assign(window, global);
-

--- a/js/interface/dialog.ts
+++ b/js/interface/dialog.ts
@@ -25,6 +25,7 @@ type DialogLineOptions = (
 )
 
 function buildForm(dialog: Dialog) {
+	dialog.form?.delete();
 	dialog.form = new InputForm(dialog.form_config);
 	let dialog_content = $(dialog.object).find('.dialog_content');
 	dialog_content.append(dialog.form.node);
@@ -520,7 +521,11 @@ export class Dialog {
 		this.hide();
 	}
 	build() {
-		if (this.object) this.object.remove();
+		if (this.object) {
+			this.form?.delete();
+			delete this.form;
+			this.object.remove();
+		}
 		this.object = document.createElement('dialog');
 		this.object.className = 'dialog';
 		this.object.id = this.id;
@@ -778,6 +783,8 @@ export class Dialog {
 		return this;
 	}
 	delete() {
+		this.form?.delete();
+		delete this.form;
 		$(this.object).remove()
 		if (this.content_vue) {
 			this.content_vue.$destroy();

--- a/js/interface/form.ts
+++ b/js/interface/form.ts
@@ -188,6 +188,7 @@ export class InputForm extends EventSystem {
 	}
 	buildForm() {
 		let jq_node = $(this.node);
+		this.deleteFormElements();
 		jq_node.empty();
 		for (let form_id in this.form_config) {
 			let input_config = this.form_config[form_id];
@@ -205,6 +206,16 @@ export class InputForm extends EventSystem {
 			jq_node.append(bar);
 		}
 		this.updateLabelWidth();
+	}
+	deleteFormElements() {
+		for (let form_id in this.form_data) {
+			this.form_data[form_id].delete();
+		}
+		this.form_data = {};
+	}
+	delete() {
+		this.deleteFormElements();
+		this.node.remove();
 	}
 	updateLabelWidth(ignore_hidden: boolean = false) {
 		this.max_label_width = 0;
@@ -331,6 +342,8 @@ export class FormElement extends EventSystem {
 	}
 	getDefault(): any {
 		return null;
+	}
+	delete() {
 	}
 	change() {
 		this.dispatchEvent('change', {changed_keys: [this.id]});
@@ -973,6 +986,7 @@ FormElement.types.vector = class FormElementVector extends FormElement {
 };
 FormElement.types.color = class FormElementColor extends FormElement {
 	colorpicker: ColorPicker
+	owns_colorpicker: boolean = false
 	build(bar: HTMLDivElement) {
 		super.build(bar);
 		if (this.options.colorpicker) this.colorpicker = this.options.colorpicker;
@@ -986,6 +1000,7 @@ FormElement.types.color = class FormElementColor extends FormElement {
 				private: true,
 				value: this.options.value
 			})
+			this.owns_colorpicker = true;
 		}
 		// @ts-ignore
 		this.colorpicker.onChange = function() {
@@ -1004,6 +1019,11 @@ FormElement.types.color = class FormElementColor extends FormElement {
 	}
 	getDefault() {
 		return '#ffffff';
+	}
+	delete() {
+		if (this.owns_colorpicker && this.colorpicker) {
+			this.colorpicker.delete();
+		}
 	}
 };
 FormElement.types.checkbox = class FormElementCheckbox extends FormElement {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Blockbench",
 	"description": "Low-poly modeling and animation software",
-	"version": "5.1.3",
+	"version": "5.1.4",
 	"license": "GPL-3.0-or-later",
 	"author": {
 		"name": "JannisX11",


### PR DESCRIPTION
Fixes #3567.

This disposes rebuilt color picker form widgets so Spectrum can remove its generated `.sp-container` from the document body instead of leaving it behind on each form rebuild.

Changes:
- Add `ColorPicker.delete()` to destroy the Spectrum instance before removing the widget.
- Add form element disposal in `InputForm` rebuild/delete paths.
- Dispose an existing dialog form before rebuilding or deleting a dialog.

Validation:
- `npm ci`
- `npx tsc --project tsconfig.json --noEmit`
- `npm run build-web`
- `npm run build-electron`
- `git diff --check`
