### PR TITLE
Fix incorrect handling of multi‑statement molang

### DIFF
--- a/js/animations/keyframe.js
+++ b/js/animations/keyframe.js
@@ -1,6 +1,6 @@
 import { markerColors } from "../marker_colors";
 import { clipboard } from "../native_apis";
-import { invertMolang } from "../util/molang";
+import { invertMolang, processMolangReturn } from "../util/molang";
 import { openMolangEditor } from "./molang_editor";
 
 export class KeyframeDataPoint {
@@ -140,26 +140,38 @@ export class Keyframe {
 			this.set(axis, value+amount, data_point);
 			return value+amount
 		}
-		var start = value.match(/^-?\s*\d+(\.\d+)?\s*(\+|-)/)
-		if (start) {
-			var number = parseFloat( start[0].substr(0, start[0].length-1) ) + amount;
-			if (number == 0) {
-				value = value.substr(start[0].length + (value[start[0].length-1] == '+' ? 0 : -1));
-				value = value.trim();
-			} else {
-				value = trimFloatNumber(number) + (start[0].substr(-2, 1) == ' ' ? ' ' : '') + value.substr(start[0].length-1);
-			}
-		} else {
 
-			var end = value.match(/(\+|-)\s*\d*(\.\d+)?\s*$/)
-			if (end) {
-				var number = (parseFloat( end[0] ) + amount)
-				value = value.substr(0, end.index) + ((number.toString()).substr(0,1)=='-'?'':'+') + trimFloatNumber(number)
-			} else {
-				value = trimFloatNumber(amount) +(value.substr(0,1)=='-'?'':'+')+ value
+		value = processMolangReturn(value, (expression) => {
+			let value = exportMolang(expression);
+			if (!value || value === '0') {
+				return amount;
 			}
-		}
-		value = value.replace(/^(0\s*\+)/, '').replace(/^0\s*-/, '-');
+			if (typeof value === 'number') {
+				return value+amount
+			}
+			var start = value.match(/^-?\s*\d+(\.\d+)?\s*(\+|-)/)
+			if (start) {
+				var number = parseFloat( start[0].substr(0, start[0].length-1) ) + amount;
+				if (number == 0) {
+					value = value.substr(start[0].length + (value[start[0].length-1] == '+' ? 0 : -1));
+					value = value.trim();
+				} else {
+					value = trimFloatNumber(number) + (start[0].substr(-2, 1) == ' ' ? ' ' : '') + value.substr(start[0].length-1);
+				}
+			} else {
+
+				var end = value.match(/(\+|-)\s*\d*(\.\d+)?\s*$/)
+				if (end) {
+					var number = (parseFloat( end[0] ) + amount)
+					value = value.substr(0, end.index) + ((number.toString()).substr(0,1)=='-'?'':'+') + trimFloatNumber(number)
+				} else {
+					value = trimFloatNumber(amount) +(value.substr(0,1)=='-'?'':'+')+ value
+				}
+			}
+			value = value.replace(/^(0\s*\+)/, '').replace(/^0\s*-/, '-');
+			return value;
+		});
+
 		this.set(axis, value, data_point)
 		return value;
 	}

--- a/js/util/molang.ts
+++ b/js/util/molang.ts
@@ -3,6 +3,31 @@ function isStringNumber(string: string) {
 	return string_num_regex.test(string);
 }
 
+export function processMolangReturn(molang: string, callback: Function): string {
+	if (molang.includes('return ')) {
+		return molang.replace(/return (.+?)(;|$)/g, (match: string, expression: string, end: string) => {
+			return `return ${callback(expression)}${end}`;
+		})
+	} else {
+		molang = molang.replace(/;+$/, '')
+		const lastSemicolonIndex = molang.lastIndexOf(';');
+		if (lastSemicolonIndex === -1) {
+			if (molang.includes('=')) {
+				return molang + ';' + callback('');
+			} else {
+				return callback(molang);
+			}
+		}
+		const before = molang.substring(0, lastSemicolonIndex);
+		const after = molang.substring(lastSemicolonIndex + 1);
+		if (after.includes('=')) {
+			return molang + ';' + callback('');
+		} else {
+			return before + ';' + callback(after);
+		}
+	}
+}
+
 const BRACKET_OPEN = '{([';
 const BRACKET_CLOSE = '})]';
 export function invertMolang(molang: string): string
@@ -17,51 +42,47 @@ export function invertMolang(molang: number|string): number|string {
 		return (-val).toString();
 	}
 
-	if (molang.includes('return ')) {
-		return molang.replace(/return (.+?)(;|$)/g, (match: string, expression: string, end: string) => {
-			return `return ${invertMolang(expression)}${end}`;
-		})
-	}
-
-	let invert = true;
-	let bracket_depth = 0;
-	let last_operator: undefined | string;
-	let result = '';
-	for (let char of molang) {
-		if (!bracket_depth) {
-			let operator: undefined | string;
-			let had_input = true;
-			if (char == '-' && last_operator != '*' && last_operator != '/') {
-				if (!invert && !last_operator) result += '+';
-				invert = false;
-				continue;
-			} else if (char == ' ' || char == '\n') {
-				had_input = false;
-			} else if (char == '+' && last_operator != '*' && last_operator != '/') {
-				result += '-';
-				invert = false;
-				continue;
-			} else if ('?:'.includes(char)) {
-				invert = true;
-				operator = char;
-			} else if (invert) {
-				result += '-';
-				invert = false;
-			} else if ('+-*/&|'.includes(char)) {
-				operator = char;
+	return processMolangReturn(molang, (expression : string) => {
+		let invert = true;
+		let bracket_depth = 0;
+		let last_operator: undefined | string;
+		let result = '';
+		for (let char of expression) {
+			if (!bracket_depth) {
+				let operator: undefined | string;
+				let had_input = true;
+				if (char == '-' && last_operator != '*' && last_operator != '/') {
+					if (!invert && !last_operator) result += '+';
+					invert = false;
+					continue;
+				} else if (char == ' ' || char == '\n') {
+					had_input = false;
+				} else if (char == '+' && last_operator != '*' && last_operator != '/') {
+					result += '-';
+					invert = false;
+					continue;
+				} else if ('?:'.includes(char)) {
+					invert = true;
+					operator = char;
+				} else if (invert) {
+					result += '-';
+					invert = false;
+				} else if ('+-*/&|'.includes(char)) {
+					operator = char;
+				}
+				if (had_input) {
+					last_operator = operator;
+				}
 			}
-			if (had_input) {
-				last_operator = operator;
+			if (BRACKET_OPEN.includes(char)) {
+				bracket_depth++;
+			} else if (BRACKET_CLOSE.includes(char)) {
+				bracket_depth--;
 			}
+			result += char;
 		}
-		if (BRACKET_OPEN.includes(char)) {
-			bracket_depth++;
-		} else if (BRACKET_CLOSE.includes(char)) {
-			bracket_depth--;
-		}
-		result += char;
-	}
-	return result;
+		return result;
+	});
 }
 function testInvertMolang(input: string) {
 	let positive_result = Animator.MolangParser.parse(input);
@@ -76,10 +97,12 @@ function testInvertMolang(input: string) {
 
 const global = {
 	invertMolang,
-	testInvertMolang
+	testInvertMolang,
+	processMolangReturn
 };
 declare global {
 	const invertMolang: typeof global.invertMolang
 	const testInvertMolang: typeof global.testInvertMolang
+	const processMolangReturn: typeof global.processMolangReturn
 }
 Object.assign(window, global);


### PR DESCRIPTION
`Keyframe.offset()` and `invertMolang()` both failed to correctly process multi‑statement molang expressions (multiple statements separated by semicolons). This caused errors when parsing or transforming return values and chained expressions.  
This commit introduces a unified utility to properly handle multi‑statement molang and applies it to both methods.

## Changes

### js/util/molang.ts
- Add `processMolangReturn()` utility, which extracts the effective return expression from multi‑statement molang  
  - If an explicit `return` exists, it is processed directly  
  - Otherwise, the last expression is checked:  
    - If it is not an assignment, it is passed to the callback for processing  
    - If it is an assignment, an empty expression is passed to the callback and appended to the original multi‑statement sequence  
- Export `processMolangReturn` globally alongside existing molang utilities  
- Update `invertMolang()` to delegate expression handling to `processMolangReturn()`

### js/animations/keyframe.js
- Refactor `offset()` to use `processMolangReturn()` for consistent handling of multi‑statement molang  