### PR TITLE
Fix dragging groups/elements into a selected group

### DIFF
--- a/js/outliner/outliner.js
+++ b/js/outliner/outliner.js
@@ -314,7 +314,6 @@ export class NodePreviewController extends EventSystem {
 	}
 	updateVisibility(element) {
 		element.mesh.visible = element.visibility;
-
 		this.dispatchEvent('update_visibility', {element});
 	}
 	updateSelection(element) {
@@ -580,7 +579,6 @@ export function canAddOutlinerSelectionTo(target, clicked_on) {
 	if (clicked_on instanceof OutlinerElement && !clicked_on.selected) {
 		nodes_to_move = [clicked_on];
 	} else {
-		if (target.selected) return false;
 		nodes_to_move = Outliner.selected.concat(Group.selected).filter(element => element.parent == 'root' || element.parent.selected != true);
 	}
 	return canAddOutlinerNodesTo(nodes_to_move, target);

--- a/js/outliner/outliner.js
+++ b/js/outliner/outliner.js
@@ -314,6 +314,7 @@ export class NodePreviewController extends EventSystem {
 	}
 	updateVisibility(element) {
 		element.mesh.visible = element.visibility;
+
 		this.dispatchEvent('update_visibility', {element});
 	}
 	updateSelection(element) {


### PR DESCRIPTION
Closes #3464

This PR fixes an issue where dragging and dropping a group or element into a target group did nothing if the target group was already selected.

**Changes:**
- Removed the `if (target.selected) return false;` check in the `canAddOutlinerSelectionTo` function.
- Circular references and invalid parents/children are still properly prevented by subsequent checks inside `canAddOutlinerNodesTo` and `moveOutlinerSelectionTo`.