### PR TITLE
Fix TGA texture loading in skin format and fix Phantom skin preset

### DIFF
--- a/js/formats/minecraft/skin.ts
+++ b/js/formats/minecraft/skin.ts
@@ -544,7 +544,15 @@ export const skin_dialog = new Dialog({
 						for (let path of model.external_textures) {
 							let frame = new CanvasFrame();
 							let resource_path = `https://raw.githubusercontent.com/Mojang/bedrock-samples/preview/resource_pack/textures/${path}?raw=true`;
-							frame.loadFromURL(resource_path).then(() => {
+							let load_promise;
+							if (path.endsWith('.tga')) {
+								load_promise = fetch(resource_path)
+									.then(res => res.arrayBuffer())
+									.then(buffer => frame.loadFromTGA(new Uint8Array(buffer)));
+							} else {
+								load_promise = frame.loadFromURL(resource_path);
+							}
+							load_promise.then(() => {
 								let dataUrl = frame.canvas.toDataURL();
 								let texture = new Texture({
 									internal: true,
@@ -7014,7 +7022,7 @@ skin_presets.phantom = {
 	display_name: 'Phantom',
 	model: `{
 		"name": "phantom",
-		"external_textures": ["entity/llama/llama.png"],
+		"external_textures": ["entity/phantom.tga"],
 		"eyes": [
 			[5, 6, 2, 1],
 			[10, 6, 2, 1]


### PR DESCRIPTION
Closes #3564

This PR fixes the issue where loading the Phantom skin preset from Minecraft incorrectly downloaded the Llama texture (due to an incorrect path in the preset config). It also adds support for loading `.tga` textures dynamically in the skin format.

**Changes:**
- Updated the Phantom skin preset `external_textures` path from `entity/llama/llama.png` to `entity/phantom.tga`.
- Added support in `skin.ts` to detect `.tga` files, fetch them as binary array buffers, and load them using the CanvasFrame TGA decoder.
