### PR TITLE
Fix per_group_texture not working with meshes

### DIFF
--- a/js/outliner/types/mesh.js
+++ b/js/outliner/types/mesh.js
@@ -7,6 +7,7 @@ export class MeshFace extends Face {
 		this.mesh = mesh;
 		this.uv = {};
 		this.texture = false;
+		this.element = mesh;
 		if (data) {
 			this.extend(data);
 		}


### PR DESCRIPTION
## The bug

This is a bug that appears in a pretty niche case. For the custom `ModelFormat`  for the Figura Mod, we want to use `per_group_texture`  and `meshes` together. 

The problem arises because the `getTexture()` method in the `Face` class expects all faces to have their parent as `element` which is not respected by `MeshFace`.

Here's the if statement that causes us trouble:
https://github.com/JannisX11/blockbench/blob/8fe8d9d9568de8233d77cd592744acad495d46b0/js/outliner/abstract/face.ts#L45-L47


When this method is ran by a `MeshFace`, it causes an error because `this.element` is undefined.

## Change

### js/outliner/types/cube.js

It's just one line to set the MeshFace's element to be the mesh. 
https://github.com/Buwwet/blockbench/blob/36b70a5a21ddd5b15bf61fd0adb7d63c1cd2cd39/js/outliner/types/mesh.js#L5-L15