### PR TITLE
Fix glTF UV export with external textures

### DIFF
--- a/js/formats/standards/gltf.js
+++ b/js/formats/standards/gltf.js
@@ -497,7 +497,7 @@ var codec = new Codec('gltf', {
 					trs: true,
 					binary: options.encoding == 'binary',
 					truncateDrawRange: false,
-					forcePowerOfTwoTextures: true,
+					forcePowerOfTwoTextures: options.embed_textures !== false,
 					scale_factor: 1/options.scale,
 					embedImages: options.embed_textures != false,
 					exportFaceColors: false,

--- a/js/io/project.ts
+++ b/js/io/project.ts
@@ -1164,12 +1164,6 @@ BARS.defineActions(function() {
 						}
 						Project.texture_width = texture_width;
 						Project.texture_height = texture_height;
-						if (Format.per_texture_uv_size) {
-							Texture.all.forEach(tex => {
-								tex.uv_width = texture_width;
-								tex.uv_height = texture_height;
-							});
-						}
 
 						if (Format.optional_box_uv) Project.box_uv = box_uv;
 						Canvas.updateAllUVs()

--- a/js/io/project.ts
+++ b/js/io/project.ts
@@ -1164,6 +1164,12 @@ BARS.defineActions(function() {
 						}
 						Project.texture_width = texture_width;
 						Project.texture_height = texture_height;
+						if (Format.per_texture_uv_size) {
+							Texture.all.forEach(tex => {
+								tex.uv_width = texture_width;
+								tex.uv_height = texture_height;
+							});
+						}
 
 						if (Format.optional_box_uv) Project.box_uv = box_uv;
 						Canvas.updateAllUVs()

--- a/js/lib/GLTFExporter.js
+++ b/js/lib/GLTFExporter.js
@@ -1311,7 +1311,7 @@ GLTFExporter.prototype = {
 						}
 
 						// Blockbench: Modify UV mapping for poweroftwo texture conversion
-						if (options.forcePowerOfTwoTextures) {
+						if (options.forcePowerOfTwoTextures && options.embedImages) {
 
 							if (!mesh.geometry) return;
 							let material;


### PR DESCRIPTION
## Summary

- Disable power-of-two UV scaling when exporting glTF with external textures (`embed_textures: false`)
- Only apply POT UV adjustment in `GLTFExporter` when images are embedded and actually padded

## Problem

When exporting glTF with **Embed textures** disabled, UV coordinates were scaled by `textureWidth / ceilPowerOfTwo(textureWidth)` (e.g. `3200 / 4096 = 0.78125`), but the external PNG file was left at its original size. External viewers then sampled only part of the texture, making it appear cropped even though the Blockbench viewport looked correct.

## Solution

- Tie `forcePowerOfTwoTextures` to `embed_textures` in the glTF codec
- Guard POT UV scaling in `GLTFExporter` with `embedImages`, so image padding and UV scaling stay coupled

## Test plan

- [x] Generic model with a non-power-of-two texture (e.g. 3200×3200), UV covering the full texture
- [x] Export glTF with **Embed textures** disabled → `TEXCOORD_0` max is `[1.0, 1.0]` (was `[0.78125, 0.78125]`)
- [x] Texture displays correctly in an external viewer (Blender / three.js)
- [x] Export with **Embed textures** enabled → POT padding still works for embedded images