### PR TITLE
Remove unnecessary !important usages from app CSS

### DIFF
--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -60,13 +60,14 @@
 		border-width: var(--size);
 		border-style: solid;
 		border-color: var(--color-button);
-		border-top-color: transparent !important;
-		border-left-color: transparent !important;
+		border-top-color: transparent;
+		border-left-color: transparent;
 		border-bottom-right-radius: inherit;
 		cursor: se-resize;
 	}
 	.dialog_resize_handle:hover, .dialog_resize_handle.dragging {
-		border-color: var(--color-accent);
+		border-right-color: var(--color-accent);
+		border-bottom-color: var(--color-accent);
 	}
 	.dialog_sidebar_menu_button {
 		height: 100%;
@@ -1571,21 +1572,6 @@
 	.plugin_compatibility_issue > .icon,
 	.plugin_deprecation_note > .icon {
 		vertical-align: text-bottom;
-	}
-	#plugin_list > li button {
-		min-width: 100px;
-		width: auto;
-		height: 36px;
-		float: right;
-		padding: 4px;
-		margin-left: -1px;
-		margin-top: 6px;
-		color: var(--color-text);
-		transition: width 100ms ease-in;
-	}
-	#plugin_list > li button > i {
-		float: left;
-		margin-top: 2px;
 	}
 	#plugin_list > li .title {
 		font-size: 1.34em;

--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -1132,8 +1132,20 @@
 		max-width: none;
 		pointer-events: none;
 	}
+	dialog#about div.socials a i.fa-bluesky {
+		color: #208bfe;
+	}
+	dialog#about div.socials a i.fa-twitter {
+		color: #1ea6ff;
+	}
+	dialog#about div.socials a i.fa-discord {
+		color: #5865F2;
+	}
+	dialog#about div.socials a i.fa-github {
+		color: #dddddd;
+	}
 	dialog#about div.socials a:hover i {
-		color: var(--color-light) !important;
+		color: var(--color-light);
 	}
 	dialog#about div.socials a label {
 		color: var(--color-subtle_text);

--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -246,7 +246,7 @@
 		margin-right: auto;
 	}
 	.dialog_bar.form_bar .tool > .tooltip {
-		display: none !important;
+		display: none;
 	}
 	.dialog_bar .form_overlay_tools {
 		position: absolute;
@@ -504,7 +504,8 @@
 	}
 	@media (max-device-width: 640px) {
 		dialog {
-			width: 100% !important;
+			min-width: 100%;
+			max-width: 100%;
 		}
 		dialog .dialog_content, dialog .dialog_bar.button_bar {
 			margin: 12px;
@@ -2323,7 +2324,7 @@
 /* Custom Brush Options */
 	dialog#brush_options:not(.preset_selected) div.form_bar,
 	dialog#brush_options:not(.preset_selected) hr {
-		display: none !important;
+		display: none;
 	}
 	ul#brush_preset_bar {
 		display: flex;

--- a/css/general.css
+++ b/css/general.css
@@ -17,7 +17,7 @@
 		float: left;
 	}
 	.f_right {
-		float: right !important;
+		float: right;
 	}
 	.i_b {
 		display: inline-block;

--- a/css/general.css
+++ b/css/general.css
@@ -126,9 +126,9 @@
 		background-color: var(--color-accent);
 		color: var(--color-accent_text);
 	}
-	.checkerboard, .checkerboard_trigger .checkerboard_target {
+	.checkerboard, #center.checkerboard, .checkerboard_trigger .checkerboard_target {
 		--color-checker_offset: rgba(0, 0, 0, 0.16);
-		background-color: var(--color-checkerboard) !important;
+		background-color: var(--color-checkerboard);
 		background-image: linear-gradient(45deg, var(--color-checkerboard) 25%, transparent 25%),
 						  linear-gradient(-45deg, var(--color-checkerboard) 25%, transparent 25%),
 						  linear-gradient(45deg, transparent 75%, var(--color-checkerboard) 75%),
@@ -138,7 +138,7 @@
 	}
 	body[mode=start] div#center.checkerboard {
 		background-image: none;
-		background-color: var(--color-dark) !important;
+		background-color: var(--color-dark);
 	}
 
 /*UI Elements*/

--- a/css/panels.css
+++ b/css/panels.css
@@ -1190,13 +1190,6 @@
 	}
 	.in_list_button {
 		width: 22px;
-		color: var(--color-text);
-	}
-	.in_list_button:hover {
-		color: var(--color-light);
-	}
-	.in_list_button {
-		width: 22px;
 		height: 22px;
 		color: var(--color-text);
 	}
@@ -2986,31 +2979,6 @@ span.controller_state_section_info {
 	}
 	#texture_selection_rect.ellipse {
 		border-radius: 50%;
-	}
-	#texture_pasting_overlay {
-		position: absolute;
-		pointer-events: initial !important;
-	}
-	#texture_pasting_overlay canvas {
-		pointer-events: initial !important;
-	}
-	#texture_pasting_overlay::before {
-		content: "";
-		display: block;
-		box-sizing: content-box;
-		position: absolute;
-		border: 1px dashed white;
-		margin: -1px;
-		pointer-events: none;
-		z-index: 6;
-		width: 100%;
-		height: 100%;
-	}
-	#texture_pasting_overlay > canvas {
-		box-shadow: 1px 1px 20px black;
-		cursor: move;
-		z-index: 5;
-		float: left;
 	}
 	.uv_transparent_face {
 		margin: 8px auto auto;

--- a/css/panels.css
+++ b/css/panels.css
@@ -6,15 +6,15 @@
 		flex-direction: column;
 		position: relative;
 	}
-	.panel_container.hidden {
-		display: none !important;
-	}
 	.panel_container.grow {
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
 		height: 40px;
 		min-height: 133px;
+	}
+	.panel_container.hidden {
+		display: none;
 	}
 
 	.panel {
@@ -1601,13 +1601,15 @@
 		z-index: 1;
 		pointer-events: none;
 	}
+	#timeline_body .animator_head_bar .keyframe:not(.selected) i {
+		color: #495061;
+	}
 	#timeline_body .animator_head_bar .keyframe i {
 		transform: none;
 		font-size: 6pt;
-		color: #495061;
 	}
 	#panel_timeline .keyframe.selected i {
-		color: var(--color-accent) !important;
+		color: var(--color-accent);
 		z-index: 4;
 	}
 	#panel_timeline .keyframe:hover {
@@ -2625,7 +2627,7 @@ span.controller_state_section_info {
 
 	.face_properties_toggle {
 		width: 32px;
-		flex-grow: 0 !important;
+		flex-grow: 0;
 	}
 	.face_properties_toggle > i {
 		margin: 1px auto;
@@ -2952,7 +2954,7 @@ span.controller_state_section_info {
 		display: flex;
 		height: 28px;
 	}
-	#uv_cube_face_bar li {
+	#uv_cube_face_bar li:not(.face_properties_toggle) {
 		flex-grow: 1;
 		text-align: center;
 		padding: 2px;

--- a/css/panels.css
+++ b/css/panels.css
@@ -1754,7 +1754,7 @@
 		z-index: 5;
 	}
 	#timeline_vue.graph_editor li.animator > div {
-		width: fit-content !important;
+		width: fit-content;
 		background-color: var(--color-ui);
 	}
 	.channel_head {

--- a/css/panels.css
+++ b/css/panels.css
@@ -243,7 +243,7 @@
 		flex-grow: 0;
 	}
 	.panel_container.folded > .panel {
-		display: none !important;
+		display: none;
 	}
 	.panel_container.fixed_height {
 		flex-grow: 0;
@@ -1197,7 +1197,7 @@
 		color: var(--color-light);
 	}
 	.in_list_button.unclickable {
-		color: var(--color-subtle_text) !important;
+		color: var(--color-subtle_text);
 		pointer-events: none;
 	}
 
@@ -2773,7 +2773,7 @@ span.controller_state_section_info {
 	}
 	.cube_uv_face.unselected > div,
 	.cube_box_uv.unselected > div {
-		border-color: var(--color-uv-unselected) !important;
+		border-color: var(--color-uv-unselected);
 	}
 
 	.uv_resize_side {

--- a/css/setup.css
+++ b/css/setup.css
@@ -803,8 +803,8 @@
 		border-width: 4px;
 		border-style: solid;
 		border-color: var(--corner-color);
-		border-bottom-color: transparent !important;
-		border-left-color: transparent !important;
+		border-bottom-color: transparent;
+		border-left-color: transparent;
 	}
 	div.nslide_arrow {
 		position: absolute;
@@ -831,8 +831,8 @@
 		border-width: 4px;
 		border-style: solid;
 		border-color: var(--corner-color);
-		border-bottom-color: transparent !important;
-		border-left-color: transparent !important;
+		border-bottom-color: transparent;
+		border-left-color: transparent;
 	}
 
 	input.toggle_panel {

--- a/css/setup.css
+++ b/css/setup.css
@@ -506,7 +506,7 @@
 	}
 	button:hover {
 		background: var(--color-accent);
-		color: var(--color-accent_text) !important;
+		color: var(--color-accent_text);
 	}
 	button:focus {
 	    text-decoration: underline;
@@ -517,7 +517,7 @@
     	text-decoration: underline;
 	}
 	button.minor:hover {
-		color: var(--color-light) !important;
+		color: var(--color-light);
 	}
 	button > i {
 		pointer-events: none;

--- a/css/start_screen.css
+++ b/css/start_screen.css
@@ -152,9 +152,6 @@
 	#start_screen .recent_project.thumbnail:hover .recent_project_name {
 		color: var(--color-light);
 	}
-	#start_files ul.redact li.recent_project.thumbnail .thumbnail_image {
-		background: transparent !important;
-	}
 	#start_screen .recent_project.thumbnail:hover .icon_wrapper {
 		display: block;
 	}
@@ -307,10 +304,6 @@
 			display: block;
 		}
 		#start_screen > content > section > div.start_screen_right {
-			width: 100% !important;
-			float: none;
-		}
-		#start_screen > content > section > div.start_screen_left {
 			width: 100% !important;
 			float: none;
 		}

--- a/css/start_screen.css
+++ b/css/start_screen.css
@@ -304,11 +304,12 @@
 			display: block;
 		}
 		#start_screen > content > section > div.start_screen_right {
-			width: 100% !important;
+			width: 100%;
 			float: none;
 		}
 		#start_screen > content > section > div.start_screen_left {
-			width: 100% !important;
+			min-width: 100%;
+			max-width: 100%;
 			float: none;
 		}
 		#start_screen .start_screen_features > li,

--- a/css/start_screen.css
+++ b/css/start_screen.css
@@ -311,12 +311,14 @@
 			width: 100% !important;
 			float: none;
 		}
-		#start_screen .start_screen_features > li {
-			flex-direction: column !important;
-			text-align: center !important;
+		#start_screen .start_screen_features > li,
+		#start_screen .start_screen_features > li:nth-child(odd) {
+			flex-direction: column;
+			text-align: center;
 		}
-		#start_screen .start_screen_features > li > * {
-			width: 100% !important;
+		#start_screen .start_screen_features > li > *,
+		#start_screen .start_screen_features > li > img {
+			width: 100%;
 		}
 	}
 
@@ -513,38 +515,6 @@
 		vertical-align: bottom;
 		margin-right: 3px;
 		margin-bottom: 2px;
-	}
-
-	section#keymap_preference {
-		display: block !important;
-	}
-	section#keymap_preference > ul {
-		display: grid;
-		grid-template-columns: auto auto auto;
-		grid-gap: 6px;
-		padding: 12px;
-	}
-	section#keymap_preference > h2 {
-		padding: 12px 20px;
-	}
-	section#keymap_preference > p {
-		padding: 0 20px;
-	}
-	section#keymap_preference .keymap_select_box {
-		display: inline-block;
-		padding: 12px;
-		min-height: 132px;
-		background-color: var(--color-back);
-		cursor: pointer;
-		border: 2px solid transparent;
-	}
-	section#keymap_preference .keymap_select_box:hover {
-		color: var(--color-light);
-		border-color: var(--color-accent);
-		background-color: var(--color-ui);
-	}
-	section#keymap_preference .keymap_select_box p {
-		color: var(--color-subtle_text);
 	}
 
 	#start_screen section#quick_setup {

--- a/css/window.css
+++ b/css/window.css
@@ -1069,7 +1069,7 @@
 		z-index: 8;
 	}
 	.reference_image:not(.in_scene) {
-		transform: unset !important;
+		transform: unset;
 	}
 	.reference_image.selected[reference_layer=float] > .image_content {
 		box-shadow: 3px 3px 10px rgb(0 0 0 / 70%);
@@ -1088,7 +1088,7 @@
 		z-index: 9;
 		pointer-events: initial;
 		cursor: move;
-		clip-path: none !important;
+		clip-path: none;
 	}
 	.reference_image.selected, .reference_image:hover {
 		outline: 1px solid var(--color-accent);

--- a/css/window.css
+++ b/css/window.css
@@ -409,11 +409,11 @@
 			"center"
 			"status_bar"
 			"panel_selector";
-		grid-template-columns: auto !important;
+		grid-template-columns: auto;
 		position: relative;
 	}
 	body.is_mobile.is_landscape #work_screen {
-		grid-template-columns: auto 48px !important;
+		grid-template-columns: auto 48px;
 		grid-template-rows: auto minmax(200px, 5000px) var(--status-bar-height);
 		grid-template-areas: 
 			"toolbar panel_selector"
@@ -422,7 +422,7 @@
 		position: relative;
 	}
 	body.is_mobile.is_landscape.mobile_sidebar_left #work_screen {
-		grid-template-columns: 48px auto !important;
+		grid-template-columns: 48px auto;
 		grid-template-areas: 
 			"panel_selector toolbar"
 			"panel_selector center"

--- a/css/window.css
+++ b/css/window.css
@@ -126,13 +126,13 @@
 	}
 	#preview.image_mode > .single_canvas_wrapper,
 	#preview.image_mode > .split_screen_wrapper {
-		display: none !important;
+		display: none;
 	}
 /* Resizers */
 
 
 	.resizer {
-		position: absolute !important;
+		position: absolute;
 		z-index: 12;
 		opacity: 0;
 		touch-action: none;
@@ -334,7 +334,7 @@
 		background: transparent;
 	}
 	#web_download_button a {
-		text-decoration: none !important;
+		text-decoration: none;
 		height: 100%;
 		width: 100%;
 		padding: 0 12px;
@@ -403,7 +403,7 @@
 	}
 	body.is_mobile #work_screen {
 		display: grid;
-		grid-template-rows: auto minmax(200px, 5000px) var(--status-bar-height) 38px !important;
+		grid-template-rows: auto minmax(200px, 5000px) var(--status-bar-height) 38px;
 		grid-template-areas: 
 			"toolbar"
 			"center"
@@ -414,7 +414,7 @@
 	}
 	body.is_mobile.is_landscape #work_screen {
 		grid-template-columns: auto 48px !important;
-		grid-template-rows: auto minmax(200px, 5000px) var(--status-bar-height) !important;
+		grid-template-rows: auto minmax(200px, 5000px) var(--status-bar-height);
 		grid-template-areas: 
 			"toolbar panel_selector"
 			"center panel_selector"
@@ -1020,7 +1020,7 @@
 		filter: brightness(0.7);
 	}
 	.orbit_gizmo:not(.mouse_active) .orbit_gizmo_side:hover {
-		background-color: var(--color-bright_ui) !important;
+		background-color: var(--color-bright_ui);
 		filter: brightness(1);
 	}
 	div#preview_copy_brush_outline {

--- a/js/animations/timeline.js
+++ b/js/animations/timeline.js
@@ -1782,7 +1782,7 @@ Interface.definePanels(() => {
 									</div>
 								</div>
 								<div class="animator_channel_bar"
-									v-bind:style="{width: (size*length + head_width)+'px'}"
+									v-bind:style="graph_editor_open ? {} : {width: (size*length + head_width)+'px'}"
 									v-for="(channel_options, channel) in animator.channels"
 									v-if="animator.expanded && channels[channel] != false && Condition(channel_options.condition, animator) && (!channels.hide_empty || animator[channel].length)"
 								>

--- a/js/interface/about.ts
+++ b/js/interface/about.ts
@@ -59,15 +59,15 @@ BARS.defineActions(() => {
 									<label>Website</label>
 								</a>
 								<a class="open-in-browser" href="https://bsky.app/profile/blockbench.net">
-									<i class="icon fab fa-bluesky" style="color: #208bfe;"></i>
+									<i class="icon fab fa-bluesky"></i>
 									<label>Bluesky</label>
 								</a>
 								<a class="open-in-browser" href="https://twitter.com/blockbench">
-									<i class="icon fab fa-twitter" style="color: #1ea6ff;"></i>
+									<i class="icon fab fa-twitter"></i>
 									<label>Twitter</label>
 								</a>
 								<a class="open-in-browser" href="http://discord.blockbench.net">
-									<i class="icon fab fa-discord" style="color: #5865F2;"></i>
+									<i class="icon fab fa-discord"></i>
 									<label>Discord</label>
 								</a>
 								<a class="open-in-browser" href="https://youtube.com/Blockbench3D">
@@ -75,7 +75,7 @@ BARS.defineActions(() => {
 									<label>YouTube</label>
 								</a>
 								<a class="open-in-browser" href="https://github.com/JannisX11/blockbench">
-									<i class="icon fab fa-github" style="color: #dddddd;"></i>
+									<i class="icon fab fa-github"></i>
 									<label>GitHub</label>
 								</a>
 								<a class="open-in-browser" href="https://blockbench.net/wiki">

--- a/js/interface/actions.ts
+++ b/js/interface/actions.ts
@@ -217,6 +217,7 @@ export abstract class BarItem extends EventSystem {
 				}
 			}, {passive: true})
 			action.node.addEventListener('touchstart', () => {
+				if (tooltip.closest('.dialog_bar.form_bar')) return;
 				tooltip.style.display = 'none';
 				let show_tooltip = setTimeout(() => {
 					tooltip.style.display = 'block';

--- a/js/interface/panels.ts
+++ b/js/interface/panels.ts
@@ -1267,24 +1267,26 @@ export function updateInterfacePanels() {
 	if (!Blockbench.isMobile) {
 		Interface.left_bar.style.display = Prop.show_left_bar ? 'flex' : 'none';
 		Interface.right_bar.style.display = Prop.show_right_bar ? 'flex' : 'none';
-	}
 
-	Interface.work_screen.style.setProperty(
-		'grid-template-columns',
-		Interface.left_bar_width+'px auto '+ Interface.right_bar_width +'px'
-	)
+		Interface.work_screen.style.setProperty(
+			'grid-template-columns',
+			Interface.left_bar_width+'px auto '+ Interface.right_bar_width +'px'
+		)
+	}
 	for (var key in Interface.Panels) {
 		var panel: Panel = Panels[key];
 		panel.update();
 	}
-	var left_width = Interface.left_bar.querySelector('.panel_container:not(.hidden)') ? Interface.left_bar_width : 0;
-	var right_width = Interface.right_bar.querySelector('.panel_container:not(.hidden)') ? Interface.right_bar_width : 0;
+	if (!Blockbench.isMobile) {
+		var left_width = Interface.left_bar.querySelector('.panel_container:not(.hidden)') ? Interface.left_bar_width : 0;
+		var right_width = Interface.right_bar.querySelector('.panel_container:not(.hidden)') ? Interface.right_bar_width : 0;
 
-	if (!left_width || !right_width) {
-		Interface.work_screen.style.setProperty(
-			'grid-template-columns',
-			left_width+'px auto '+ right_width +'px'
-		)
+		if (!left_width || !right_width) {
+			Interface.work_screen.style.setProperty(
+				'grid-template-columns',
+				left_width+'px auto '+ right_width +'px'
+			)
+		}
 	}
 
 	Interface.preview.style.visibility = Interface.preview.clientHeight > 80 ? 'visible' : 'hidden';

--- a/js/preview/reference_images.ts
+++ b/js/preview/reference_images.ts
@@ -295,6 +295,7 @@ export class ReferenceImage {
 			Canvas.scene.remove(this.scene_object);
 			this.node.classList.remove('in_scene');
 			this.node.style.zIndex = '';
+			this.node.style.transform = '';
 
 			switch (this.layer) {
 				case 'background':
@@ -417,11 +418,15 @@ export class ReferenceImage {
 			this.node.style.left = pos_x + 'px';
 			this.node.style.top  = pos_y + 'px';
 
-			let offset_top = preview.node.offsetTop - this.node.offsetTop;
-			let offset_right = preview.node.clientWidth + preview.node.offsetLeft - this.node.offsetLeft;
-			let offset_bottom = preview.node.clientHeight + preview.node.offsetTop - this.node.offsetTop;
-			let offset_left = preview.node.offsetLeft - this.node.offsetLeft;
-			this.node.style.clipPath = `rect(${offset_top}px ${offset_right}px ${offset_bottom}px ${offset_left}px) view-box`;
+			if (this.selected) {
+				this.node.style.clipPath = '';
+			} else {
+				let offset_top = preview.node.offsetTop - this.node.offsetTop;
+				let offset_right = preview.node.clientWidth + preview.node.offsetLeft - this.node.offsetLeft;
+				let offset_bottom = preview.node.clientHeight + preview.node.offsetTop - this.node.offsetTop;
+				let offset_left = preview.node.offsetLeft - this.node.offsetLeft;
+				this.node.style.clipPath = `rect(${offset_top}px ${offset_right}px ${offset_bottom}px ${offset_left}px) view-box`;
+			}
 
 		} else {
 			this.node.style.width = this.size[0] + 'px';


### PR DESCRIPTION
Themes have been unable to theme certain things since layer support was added. This is because layer priority is reversed for important declarations, an `!important` in the `base` layer beats one in the `plugin` or `theme` layers. So every `!important` in the app CSS was impossible for themes and plugins to override. This removes all `!important` declarations except for the three that are actually needed.

Most could just be removed with no side affects, or a simple tweak to use a better selector.
A few existed only to fight inline styles set from JS, so those got fixed via tweaking the JS and CSS together.

I also found some dead CSS along the way and removed it. These were left behind from older dialog UIs, eg the old plugin store.

Libraries that depend on an important rule (jquery-ui, spectrum, prism) are untouched.