### PR TITLE
Renable PBR GLTF export

### DIFF
--- a/js/formats/standards/gltf.js
+++ b/js/formats/standards/gltf.js
@@ -483,8 +483,8 @@ var codec = new Codec('gltf', {
 		}
 		
 		try {
-			if (BarItems.view_mode.value !== 'textured') {
-				BarItems.view_mode.set('textured');
+			if (BarItems.view_mode.value !== 'material') {
+				BarItems.view_mode.set('material');
 				BarItems.view_mode.onChange();
 			}
 			if (options.animations !== false) {


### PR DESCRIPTION
Fixes #3139

Commit `fa6e3b44c` set the view mode used when exporting to Gltf to texture mode with the commit description "Fix glTF not exporting correctly in different view modes". This makes the export work regardless of the currently selected view mode, but discards depth/normals/metalness/emissive/roughness. Using material view mode instead they get correctly exported too.

Edit: Just noticed that material mode isn't always available; I'll need to add a check for that…