### PR TITLE
Fix failed plugin download writing the error body to disk as the plugin

### DIFF
--- a/js/plugin_loader.ts
+++ b/js/plugin_loader.ts
@@ -463,13 +463,25 @@ export class Plugin {
 		}
 
 		// Download files
-		async function copyFileToDrive(origin_filename?: string, target_filename?: string, callback?: () => void) {
-			var file = fs.createWriteStream(PathModule.join(Plugins.path, target_filename));
+		async function copyFileToDrive(origin_filename?: string, target_filename?: string, callback?: () => void, on_error?: (error: Error) => void) {
+			let target_path = PathModule.join(Plugins.path, target_filename);
 			// @ts-ignore
 			https.get(Plugins.api_path+'/'+origin_filename, function(response) {
+				// Piping a non-2xx response writes the error body to disk as the
+				// plugin, which then looks installed but cannot load. fetchAbout()
+				// and fetchChangelog() guard on the status for the same reason.
+				// The stream is only opened once the response is known to be good,
+				// so a failed download leaves nothing behind.
+				if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+					response.resume();
+					on_error?.(new Error(`Could not download ${origin_filename}: HTTP ${response.statusCode}`));
+					return;
+				}
+				let file = fs.createWriteStream(target_path);
+				file.on('error', error => on_error?.(error));
 				response.pipe(file);
 				if (callback) response.on('end', callback);
-			});
+			}).on('error', error => on_error?.(error));
 		}
 		return await new Promise<void>(async (resolve, reject) => {
 			// New system
@@ -480,6 +492,10 @@ export class Plugin {
 						await scope.load(first);
 						resolve()
 					}, 20)
+				}, (error) => {
+					if (first) Blockbench.showQuickMessage(tl('message.installed_plugin_fail', [this.title]));
+					console.error(error);
+					reject(error);
 				});
 				if (this.hasImageIcon()) {
 					copyFileToDrive(`${this.id}/${this.icon}`, this.id + '.' + this.icon);
@@ -497,6 +513,10 @@ export class Plugin {
 						await scope.load(first);
 						resolve()
 					}, 20)
+				}, (error) => {
+					if (first) Blockbench.showQuickMessage(tl('message.installed_plugin_fail', [this.title]));
+					console.error(error);
+					reject(error);
 				});
 			}
 		});


### PR DESCRIPTION
Closes #3663.

`copyFileToDrive()` piped the response into the target file without looking at the status code, so when the CDN returned an error its body landed on disk as the plugin. What you end up with is a file that looks installed and can't load.

The write stream is now opened only after the response is known to be 2xx, so a failed download leaves nothing behind rather than a truncated or garbage file to clean up.

The part that isn't in the issue: the callback is what calls `resolve()` in `install()`. Just returning early on a bad status would swap a bad install for a promise that never settles, so failures go through an `on_error` callback instead. Both call sites report it the way `load()` already does when it can't run a plugin file — `installed_plugin_fail`, `console.error`, `reject` — rather than inventing a new path. Also hooked up `error` on the request and on the write stream, since those were silent too.

The icon download at the third call site deliberately gets no handler. A missing icon shouldn't fail the install, and it was already fire-and-forget.

Checked with `tsc --noEmit -p tsconfig.json` — no errors in `plugin_loader.ts`. I didn't run a full electron build, so flagging that rather than implying I did.
