### PR TITLE
A few quality of life changes to dialog file inputs.

### DIFF
--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -372,6 +372,9 @@
 	.form_bar_file .input_wrapper input {
 		width: 100%;
 		padding-right: 30px;
+		direction: rtl;
+		text-align: left;
+		text-overflow: ellipsis;
 	}
 	.form_bar_file .input_wrapper > .material-icons {
 		position: absolute;

--- a/css/dialogs.css
+++ b/css/dialogs.css
@@ -376,6 +376,10 @@
 		text-align: left;
 		text-overflow: ellipsis;
 	}
+	.form_bar_file .input_wrapper.drag_hover input {
+		border-color: var(--color-accent);
+		background-color: var(--color-selected);
+	}
 	.form_bar_file .input_wrapper > .material-icons {
 		position: absolute;
 		margin-left: -28px;

--- a/js/file_system.ts
+++ b/js/file_system.ts
@@ -629,29 +629,29 @@ export namespace Filesystem {
 	document.ondragover = function(event) {
 		event.preventDefault()
 	}
+	export function getFilePaths(file_names: FileList): string[] {
+		let paths: string[] = [];
+		if (isApp) {
+			for (let file of file_names) {
+				if ('path' in file && typeof file.path == 'string' && file.path) {
+					paths.push(file.path);
+				} else {
+					let path = webUtils.getPathForFile(file);
+					if (path) paths.push(path);
+				}
+			}
+		} else {
+			paths = [...file_names] as unknown as string[];
+		}
+		return paths;
+	}
+
 	document.body.ondrop = function(event) {
 		event.preventDefault()
 		let text = event.dataTransfer.getData('text/plain');
 
 		if (text) {
 			Blockbench.dispatchEvent('drop_text', {text});
-		}
-
-		function getFilePaths(file_names: FileList): string[] {
-			let paths: string[] = [];
-			if (isApp) {
-				for (let file of file_names) {
-					if ('path' in file && typeof file.path == 'string' && file.path) {
-						paths.push(file.path);
-					} else {
-						let path = webUtils.getPathForFile(file);
-						if (path) paths.push(path);
-					}
-				}
-			} else {
-				paths = [...file_names] as unknown as string[];
-			}
-			return paths;
 		}
 
 		let handled = false;

--- a/js/interface/form.ts
+++ b/js/interface/form.ts
@@ -2,8 +2,9 @@ import { Blockbench } from "../api"
 import { Clipbench } from "../copy_paste"
 import { Filesystem } from "../file_system"
 import { tl } from "../languages"
+import { fs, PathModule } from "../native_apis"
 import { EventSystem } from "../util/event_system"
-import { getStringWidth, pureMarked } from "../util/util"
+import { getStringWidth, pathToExtension, pureMarked } from "../util/util"
 import { Interface } from "./interface"
 
 type ReadType = Filesystem.ReadType;
@@ -1143,14 +1144,50 @@ class FormElementFile extends FormElement {
 			this.updateInput();
 		})
 
+		const fileCB = (files) => {
+			this.value = files[0].path;
+			this.content = files[0].content;
+			this.file = files[0];
+			this.updateInput();
+			scope.change();
+		}
+
+		if (this.options.type != 'save') {
+			this.input_wrapper.addEventListener('dragover', event => {
+				if (!event.dataTransfer?.types.includes('Files')) return;
+				event.preventDefault();
+				event.stopPropagation();
+				this.input_wrapper.classList.add('drag_hover');
+			})
+			this.input_wrapper.addEventListener('dragleave', event => {
+				if (this.input_wrapper.contains(event.relatedTarget as Node)) return;
+				this.input_wrapper.classList.remove('drag_hover');
+			})
+			this.input_wrapper.addEventListener('drop', event => {
+				this.input_wrapper.classList.remove('drag_hover');
+				if (!event.dataTransfer?.files.length) return;
+				event.preventDefault();
+				event.stopPropagation();
+
+				let paths = Filesystem.getFilePaths(event.dataTransfer.files);
+				if (this.options.type == 'folder') {
+					let path = paths[0] as string;
+					fileCB([{path: fs.statSync(path).isDirectory() ? path : PathModule.dirname(path)}]);
+					return;
+				}
+				let extensions = this.options.extensions;
+				let index = [...event.dataTransfer.files].findIndex(file => {
+					return !extensions?.length || extensions.includes(pathToExtension(file.name));
+				})
+				if (index == -1) {
+					Blockbench.showQuickMessage('message.unsupported_file_extension.title');
+					return;
+				}
+				Filesystem.read([paths[index]], {readtype: this.options.readtype}, fileCB);
+			})
+		}
+
 		input_wrapper.on('click', e => {
-			const fileCB = (files) => {
-				this.value = files[0].path;
-				this.content = files[0].content;
-				this.file = files[0];
-				this.updateInput();
-				scope.change();
-			}
 			switch (this.options.type) {
 				case 'file':
 					Blockbench.import({

--- a/js/interface/form.ts
+++ b/js/interface/form.ts
@@ -1112,6 +1112,7 @@ class FormElementFile extends FormElement {
 	value: string
 	content: any
 	input: HTMLInputElement
+	input_wrapper: HTMLDivElement
 	build(bar: HTMLDivElement) {
 		super.build(bar);
 		if (this.options.type == 'folder' && !isApp) return;
@@ -1120,11 +1121,12 @@ class FormElementFile extends FormElement {
 
 		let input = $(`<input class="dark_bordered half" class="focusable_input" type="text" id="${this.id}" style="pointer-events: none;" disabled>`);
 		this.input = input[0] as HTMLInputElement;
-		this.input.value = settings.streamer_mode.value ? `[${tl('generic.redacted')}]` : this.value || '';
 		let input_wrapper = $('<div class="input_wrapper"></div>');
+		this.input_wrapper = input_wrapper[0] as HTMLDivElement;
 		input_wrapper.append(input);
 		bar.append(input_wrapper[0]);
 		bar.classList.add('form_bar_file');
+		this.updateInput();
 
 		switch (this.options.type) {
 			case 'file': 	input_wrapper.append('<i class="material-icons">insert_drive_file</i>'); break;
@@ -1138,7 +1140,7 @@ class FormElementFile extends FormElement {
 			this.value = '';
 			delete this.content;
 			delete this.file;
-			input.val('');
+			this.updateInput();
 		})
 
 		input_wrapper.on('click', e => {
@@ -1146,7 +1148,7 @@ class FormElementFile extends FormElement {
 				this.value = files[0].path;
 				this.content = files[0].content;
 				this.file = files[0];
-				input.val(settings.streamer_mode.value ? `[${tl('generic.redacted')}]` : this.value);
+				this.updateInput();
 				scope.change();
 			}
 			switch (this.options.type) {
@@ -1174,12 +1176,21 @@ class FormElementFile extends FormElement {
 						custom_writer: () => {},
 					}, path => {
 						this.value = path;
-						input.val(settings.streamer_mode.value ? `[${tl('generic.redacted')}]` : this.value);
+						this.updateInput();
 						scope.change();
 					});
 					break;
 			}
 		})
+	}
+	updateInput() {
+		let value = settings.streamer_mode.value ? `[${tl('generic.redacted')}]` : this.value || '';
+		this.input.value = value ? value + '\u200E' : '';
+		if (value) {
+			this.input_wrapper.title = value;
+		} else {
+			this.input_wrapper.removeAttribute('title');
+		}
 	}
 	getValue(): Filesystem.FileResult | string | any {
 		if (this.options.return_as == 'file') {
@@ -1198,7 +1209,7 @@ class FormElementFile extends FormElement {
 		} else {
 			this.content = value;
 		}
-		$(this.input).val(settings.streamer_mode.value ? `[${tl('generic.redacted')}]` : this.value);
+		this.updateInput();
 	}
 	getDefault() {
 		return '';


### PR DESCRIPTION
* Long paths overflow on the left, so you see the file name instead of the drive letter.
* Full path on hover as a tooltip. Goes on the wrapper, since the input has `pointer-events: none`.
* Files can be dropped onto an input. Stops propagation so the global drag handlers don't open the file as a project instead.