### PR TITLE
Load image files past the browser cache

### DIFF
--- a/js/file_system.ts
+++ b/js/file_system.ts
@@ -144,6 +144,15 @@ export namespace Filesystem {
 		}
 	}
 
+
+	// MARK: Image Source
+	let image_version = 0;
+	export function getImageSource(file: FileResult | string): string {
+		let source = typeof file == 'string' ? file : (file.content ?? file.path);
+		if (typeof source != 'string' || source.startsWith('data:')) return source as string;
+		if (!isApp) return source;
+		return source.replace(/#/g, '%23').replace(/\?\d+$/, '') + '?' + (++image_version);
+	}
 	
 	// MARK: Read
 	export function readFile(files: string[] | FileList, options: ReadOptions = {}, callback?: (files: FileResult[]) => void) {

--- a/js/io/extrude_image.js
+++ b/js/io/extrude_image.js
@@ -1,3 +1,4 @@
+import { Filesystem } from "../file_system";
 //Extruder
 export const Extruder = {
 	dialog: new Dialog({
@@ -43,7 +44,7 @@ export const Extruder = {
 		var ctx = Extruder.canvas.getContext('2d')
 
 		Extruder.ext_img = new Image()
-		Extruder.ext_img.src = isApp ? file.path.replace(/#/g, '%23') : file.content
+		Extruder.ext_img.src = Filesystem.getImageSource(file)
 		Extruder.image_file = file
 		Extruder.ext_img.style.imageRendering = 'pixelated'
 		Extruder.canvas.style.imageRendering = 'pixelated'

--- a/js/io/io.js
+++ b/js/io/io.js
@@ -1,3 +1,4 @@
+import { Filesystem } from "../file_system";
 import { shell } from "../native_apis";
 import { Extruder } from './extrude_image'
 
@@ -119,7 +120,7 @@ export async function loadImages(files, event) {
 
 	let img = new Image();
 	await new Promise((resolve, reject) => {
-		img.src = isApp ? files[0].path : files[0].content;
+		img.src = Filesystem.getImageSource(files[0]);
 		img.onload = resolve;
 		// TGA images will fail, should still continue
 		img.onerror = resolve;

--- a/js/preview/screenshot.js
+++ b/js/preview/screenshot.js
@@ -1,3 +1,4 @@
+import { Filesystem } from "../file_system";
 import { currentwindow, fs, nativeImage } from "../native_apis";
 import { applyPalette, quantize } from "../util/gif";
 
@@ -489,7 +490,7 @@ export const Screencam = {
 		}
 		if (options.background_image) {
 			vars.background_image = new Image();
-			vars.background_image.src = options.background_image
+			vars.background_image.src = Filesystem.getImageSource(options.background_image)
 			vars.background_image.onerror = () => {
 				vars.background_image = null;
 			}

--- a/js/texturing/color.js
+++ b/js/texturing/color.js
@@ -1,3 +1,4 @@
+import { Filesystem } from "../file_system";
 import { Blockbench } from "../api";
 import { ipcRenderer } from "../native_apis";
 import { colorDistance } from "../util/util";
@@ -115,7 +116,7 @@ export const ColorPanel = {
 
 		if (extension == 'png') {
 			var img = new Image();
-			img.src = file.content || file.path.replace(/#/g, '%23');
+			img.src = Filesystem.getImageSource(file);
 			img.onload = function() {
 				var c = document.createElement('canvas');
 				var ctx = c.getContext('2d');

--- a/js/texturing/layers.ts
+++ b/js/texturing/layers.ts
@@ -1,3 +1,4 @@
+import { Filesystem } from "../file_system";
 import { getFocusedTextInput } from "../interface/keyboard"
 import { Property } from "../util/property"
 
@@ -871,7 +872,7 @@ BARS.defineActions(() => {
 				for (let file of files) {
 					let img = new Image();
 					await new Promise((resolve, reject) => {
-						img.src = isApp ? file.path : file.content as string;
+						img.src = Filesystem.getImageSource(file);
 						img.onload = resolve;
 						img.onerror = reject;
 					})


### PR DESCRIPTION
Loading an image by file path returns the browser's cached copy, so after the file changes on disk you keep getting the old one. Textures and reference images already append a version to the url to avoid this.

Adds `Filesystem.getImageSource` using the same convention, and uses it in the five places that loaded a path directly:

* extruding a texture
* importing an image as a layer
* importing a palette
* the load image dialog
* the gif recorder background


To reproduce, extrude a texture, edit the png outside blockbench so blockbench auto-reloads it, extrude again. The second extrusion uses the old pixels.
