### PR TITLE
Disable preview scenes in the GUI display slot

### DIFF
--- a/js/display_mode/display_mode.js
+++ b/js/display_mode/display_mode.js
@@ -889,6 +889,7 @@ export function exitDisplaySettings() {		//Enterung Display Setting Mode, change
 	}
 
 	main_preview.fullscreen()
+	PreviewScene.updateVisibility();
 
 	resizeWindow()
 	ReferenceImage.updateAll()
@@ -1079,6 +1080,7 @@ export function loadDisp(key) {	//Loads The Menu and slider values, common for a
 	DisplayMode.updateGUILight();
 	Toolbars.display.update();
 	updateGUISlotCrop();
+	PreviewScene.updateVisibility();
 }
 DisplayMode.loadThirdRight = function() {	//Loader
 	loadDisp('thirdperson_righthand')

--- a/js/preview/preview_scenes.ts
+++ b/js/preview/preview_scenes.ts
@@ -153,11 +153,6 @@ export class PreviewScene {
 		}
 		if (PreviewScene.active) PreviewScene.active.unselect();
 
-		Canvas.global_light_color.copy(this.light_color as THREE.Color);
-		Canvas.global_light_side = this.light_side;
-		Canvas.scene.background = this.cubemap;
-		Canvas.scene.fog = this.fog;
-
 		if (this.fov && !(Modes.display && DisplayMode.display_slot.startsWith('firstperson'))) {
 			Preview.selected.setFOV(this.fov);
 		}
@@ -165,12 +160,9 @@ export class PreviewScene {
 		PreviewModel.getActiveModels().forEach(model => {
 			model.update();
 		});
-		this.preview_models.forEach(model => {
-			model.enable();
-		})
 		PreviewScene.active = this;
 		Blockbench.dispatchEvent('select_preview_scene', {scene: this});
-		Canvas.updateShading();
+		PreviewScene.updateVisibility();
 	}
 	/**
 	 * Unselects this preview scene
@@ -180,16 +172,28 @@ export class PreviewScene {
 			model.disable();
 		})
 
-		Canvas.global_light_color.set(0xffffff);
-		Canvas.global_light_side = 0;
-		if (this.cubemap) scene.background = null;
-		if (this.fog) scene.fog = null;
 		if (this.fov && !(Modes.display && DisplayMode.display_slot.startsWith('firstperson'))) {
 			Preview.all.forEach(preview => preview.setFOV(settings.fov.value as number));
 		}
 		Blockbench.dispatchEvent('unselect_preview_scene', {scene: this});
-		Canvas.updateShading();
 		PreviewScene.active = null;
+		PreviewScene.updateVisibility();
+	}
+	static updateVisibility() {
+		let scene = PreviewScene.active;
+		let show = !!scene && !(Modes.display && DisplayMode.display_slot == 'gui');
+		scene?.preview_models.forEach(model => show ? model.enable() : model.disable());
+		Canvas.global_light_color.set(0xffffff);
+		Canvas.global_light_side = 0;
+		Canvas.scene.background = null;
+		Canvas.scene.fog = null;
+		if (scene && show) {
+			Canvas.global_light_color.copy(scene.light_color as THREE.Color);
+			Canvas.global_light_side = scene.light_side;
+			Canvas.scene.background = scene.cubemap;
+			Canvas.scene.fog = scene.fog;
+		}
+		Canvas.updateShading();
 	}
 	delete() {
 		delete PreviewScene.scenes[this.id];


### PR DESCRIPTION
The GUI display slot renders behind the preview scene, and the scene covers the view anyway.

This disables preview scenes while the GUI slot is open. The scene stays selected, so it comes back when you switch to another slot.