### PR TITLE
Fix shade and shade direction override both being available

### DIFF
--- a/js/formats/java/java_block.ts
+++ b/js/formats/java/java_block.ts
@@ -137,7 +137,7 @@ const codec = new Codec('java_block', {
 					element.to[i] += s.inflate;
 				}
 			}
-			if (Format.java_cube_shade_toggle && s.shade === false) {
+			if (Format.java_cube_shading_properties && !Format.java_cube_shade_direction_override && s.shade === false) {
 				element.shade = false
 			}
 			if (s.light_emission) {
@@ -902,15 +902,6 @@ Object.defineProperty(format, 'rotation_limit', {
 	get() {
 		try {
 			return !VersionUtil.compare(Project.java_block_version, '>=', '1.21.11');
-		} catch (err) {
-			return true;
-		}
-	}
-})
-Object.defineProperty(format, 'java_cube_shade_toggle', {
-	get() {
-		try {
-			return !VersionUtil.compare(Project.java_block_version, '>=', '26.3');
 		} catch (err) {
 			return true;
 		}

--- a/js/formats/java/java_block.ts
+++ b/js/formats/java/java_block.ts
@@ -137,13 +137,13 @@ const codec = new Codec('java_block', {
 					element.to[i] += s.inflate;
 				}
 			}
-			if (s.shade === false) {
+			if (Format.java_cube_shade_toggle && s.shade === false) {
 				element.shade = false
 			}
 			if (s.light_emission) {
 				element.light_emission = s.light_emission;
 			}
-			if (s.shade_direction_override) {
+			if (Format.java_cube_shade_direction_override && s.shade_direction_override) {
 				element.shade_direction_override = s.shade_direction_override;
 			}
 			if (!s.rotation.allEqual(0) || (!s.origin.allEqual(0) && settings.java_export_pivots.value)) {
@@ -415,6 +415,9 @@ const codec = new Codec('java_block', {
 
 		if (!import_to_current_project && typeof model.format_version == 'string') {
 			Project.java_block_version = model.format_version;
+		}
+		if (!Format.java_cube_shade_direction_override && model.elements instanceof Array && model.elements.find(element => element.shade_direction_override)) {
+			Project.java_block_version = '26.3';
 		}
 
 		//Load
@@ -901,6 +904,24 @@ Object.defineProperty(format, 'rotation_limit', {
 			return !VersionUtil.compare(Project.java_block_version, '>=', '1.21.11');
 		} catch (err) {
 			return true;
+		}
+	}
+})
+Object.defineProperty(format, 'java_cube_shade_toggle', {
+	get() {
+		try {
+			return !VersionUtil.compare(Project.java_block_version, '>=', '26.3');
+		} catch (err) {
+			return true;
+		}
+	}
+})
+Object.defineProperty(format, 'java_cube_shade_direction_override', {
+	get() {
+		try {
+			return VersionUtil.compare(Project.java_block_version, '>=', '26.3');
+		} catch (err) {
+			return false;
 		}
 	}
 })

--- a/js/formats/java/java_block.ts
+++ b/js/formats/java/java_block.ts
@@ -495,6 +495,15 @@ const codec = new Codec('java_block', {
 			model.elements.forEach((obj: ElementTemplate) => {
 				let base_cube = new Cube(obj);
 				if (obj.__comment) base_cube.name = obj.__comment
+
+				// Shade backwards compatibility
+				if (obj.shade == false && Format.java_cube_shade_direction_override) {
+					base_cube.shade_direction_override = 'up';
+				} else if (obj.shade_direction_override && !Format.java_cube_shade_direction_override) {
+					base_cube.shade = false;
+				}
+
+				// Rotation
 				if (typeof obj.rotation == 'object') {
 					if (obj.rotation.origin) {
 						base_cube.extend({origin: obj.rotation.origin});

--- a/js/interface/setup_settings.js
+++ b/js/interface/setup_settings.js
@@ -277,6 +277,7 @@ function setupSettings() {
 	}});
 	new Setting('default_java_block_version',		{category: 'defaults', type: 'select', value: 'latest', options: {
 		latest: 'Latest',
+		'1.21.11': '1.21.11 - 26.2',
 		'1.21.6': '1.21.6 - 1.21.10',
 		'1.9.0': '1.9 - 1.21.5',
 	}});

--- a/js/io/format.ts
+++ b/js/io/format.ts
@@ -279,11 +279,7 @@ export interface FormatFeatures {
 	 */
 	java_cube_shading_properties: boolean
 	/**
-	 * Enables the boolean shade property on Minecraft Java block/item model cubes. Removed from the model format in 26.3, where it is replaced by java_cube_shade_direction_override
-	 */
-	java_cube_shade_toggle: boolean
-	/**
-	 * Enables the shade direction override property on Minecraft Java block/item model cubes. Added to the model format in 26.3, replacing java_cube_shade_toggle
+	 * Enables the shade direction override property on Minecraft Java block/item model cubes. Added to the model format in 26.3, replacing the shade boolean property
 	 */
 	java_cube_shade_direction_override: boolean
 	/**
@@ -692,7 +688,6 @@ new Property(ModelFormat, 'boolean', 'rotation_limit');
 new Property(ModelFormat, 'boolean', 'rotation_snap');
 new Property(ModelFormat, 'boolean', 'uv_rotation');
 new Property(ModelFormat, 'boolean', 'java_cube_shading_properties');
-new Property(ModelFormat, 'boolean', 'java_cube_shade_toggle');
 new Property(ModelFormat, 'boolean', 'java_cube_shade_direction_override');
 new Property(ModelFormat, 'boolean', 'java_face_properties');
 new Property(ModelFormat, 'boolean', 'cullfaces');

--- a/js/io/format.ts
+++ b/js/io/format.ts
@@ -279,6 +279,14 @@ export interface FormatFeatures {
 	 */
 	java_cube_shading_properties: boolean
 	/**
+	 * Enables the boolean shade property on Minecraft Java block/item model cubes. Removed from the model format in 26.3, where it is replaced by java_cube_shade_direction_override
+	 */
+	java_cube_shade_toggle: boolean
+	/**
+	 * Enables the shade direction override property on Minecraft Java block/item model cubes. Added to the model format in 26.3, replacing java_cube_shade_toggle
+	 */
+	java_cube_shade_direction_override: boolean
+	/**
 	 * Enables cullfaces, the ability on faces in Minecraft block models to set a direction, that, if covered by another block, will cause the face to unrender
 	 */
 	cullfaces: boolean
@@ -684,6 +692,8 @@ new Property(ModelFormat, 'boolean', 'rotation_limit');
 new Property(ModelFormat, 'boolean', 'rotation_snap');
 new Property(ModelFormat, 'boolean', 'uv_rotation');
 new Property(ModelFormat, 'boolean', 'java_cube_shading_properties');
+new Property(ModelFormat, 'boolean', 'java_cube_shade_toggle');
+new Property(ModelFormat, 'boolean', 'java_cube_shade_direction_override');
 new Property(ModelFormat, 'boolean', 'java_face_properties');
 new Property(ModelFormat, 'boolean', 'cullfaces');
 new Property(ModelFormat, 'boolean', 'select_texture_for_particles');

--- a/js/io/project.ts
+++ b/js/io/project.ts
@@ -612,12 +612,13 @@ new Property(ModelProject, 'string', 'modded_entity_version', {
 });
 new Property(ModelProject, 'string', 'java_block_version', {
 	label: 'dialog.project.java_block_version',
-	default: () => settings.default_java_block_version.value == 'latest' ? '1.21.11' : settings.default_java_block_version.value,
+	default: () => settings.default_java_block_version.value == 'latest' ? '26.3' : settings.default_java_block_version.value,
 	condition: {formats: ['java_block']},
 	options: {
 		'1.9.0': '1.9 - 1.21.5',
 		'1.21.6': '1.21.6 - 1.21.10',
-		'1.21.11': '1.21.11+',
+		'1.21.11': '1.21.11 - 26.2',
+		'26.3': '26.3+',
 	}
 });
 new Property(ModelProject, 'string', 'credit', {
@@ -1267,6 +1268,7 @@ BARS.defineActions(function() {
 					Blockbench.dispatchEvent('update_project_settings', formResult);
 
 					BARS.updateConditions()
+					updateSelection()
 					if (Project.EditSession) {
 						let metadata = {
 							texture_width: Project.texture_width,

--- a/js/modeling/transform.js
+++ b/js/modeling/transform.js
@@ -1856,7 +1856,7 @@ BARS.defineActions(function() {
 	new Toggle('toggle_shade', {
 		icon: 'wb_sunny',
 		category: 'transform',
-		condition: () => Format.java_cube_shading_properties && Modes.edit,
+		condition: () => Format.java_cube_shading_properties && Format.java_cube_shade_toggle && Modes.edit,
 		onChange() {toggleElementProperty('shade')}
 	})
 	new Toggle('toggle_mirror_uv', {

--- a/js/modeling/transform.js
+++ b/js/modeling/transform.js
@@ -1856,7 +1856,7 @@ BARS.defineActions(function() {
 	new Toggle('toggle_shade', {
 		icon: 'wb_sunny',
 		category: 'transform',
-		condition: () => Format.java_cube_shading_properties && Format.java_cube_shade_toggle && Modes.edit,
+		condition: () => Format.java_cube_shading_properties && !Format.java_cube_shade_direction_override && Modes.edit,
 		onChange() {toggleElementProperty('shade')}
 	})
 	new Toggle('toggle_mirror_uv', {

--- a/js/outliner/outliner.js
+++ b/js/outliner/outliner.js
@@ -56,7 +56,7 @@ export const Outliner = {
 		},
 		shade: {
 			id: 'shade',
-			condition: {modes: ['edit'], features: ['java_cube_shading_properties']},
+			condition: {modes: ['edit'], features: ['java_cube_shading_properties', 'java_cube_shade_toggle']},
 			title: tl('switches.shade'),
 			icon: 'fa-star',
 			icon_off: 'far.fa-star',

--- a/js/outliner/outliner.js
+++ b/js/outliner/outliner.js
@@ -56,7 +56,7 @@ export const Outliner = {
 		},
 		shade: {
 			id: 'shade',
-			condition: {modes: ['edit'], features: ['java_cube_shading_properties', 'java_cube_shade_toggle']},
+			condition: {modes: ['edit'], features: ['java_cube_shading_properties'], method: () => !Format.java_cube_shade_direction_override},
 			title: tl('switches.shade'),
 			icon: 'fa-star',
 			icon_off: 'far.fa-star',

--- a/js/outliner/types/cube.js
+++ b/js/outliner/types/cube.js
@@ -1083,7 +1083,7 @@ new Property(Cube, 'boolean', 'rescale', {
 new Property(Cube, 'boolean', 'locked');
 new Property(Cube, 'boolean', 'shade', {
 	default: true,
-	condition: {features: ['java_cube_shading_properties']},
+	condition: {features: ['java_cube_shading_properties', 'java_cube_shade_toggle']},
 	inputs: {
 		element_panel: {
 			input: {label: 'switches.shade', type: 'checkbox'},
@@ -1092,7 +1092,7 @@ new Property(Cube, 'boolean', 'shade', {
 });
 new Property(Cube, 'enum', 'shade_direction_override', {
 	default: '',
-	condition: {features: ['java_cube_shading_properties']},
+	condition: {features: ['java_cube_shading_properties', 'java_cube_shade_direction_override']},
 	inputs: {
 		element_panel: {
 			input: {label: 'cube.shade_direction_override', description: 'cube.shade_direction_override.desc', type: 'select', options: {

--- a/js/outliner/types/cube.js
+++ b/js/outliner/types/cube.js
@@ -1083,7 +1083,7 @@ new Property(Cube, 'boolean', 'rescale', {
 new Property(Cube, 'boolean', 'locked');
 new Property(Cube, 'boolean', 'shade', {
 	default: true,
-	condition: {features: ['java_cube_shading_properties', 'java_cube_shade_toggle']},
+	condition: {features: ['java_cube_shading_properties'], method: () => !Format.java_cube_shade_direction_override},
 	inputs: {
 		element_panel: {
 			input: {label: 'switches.shade', type: 'checkbox'},

--- a/lang/en.json
+++ b/lang/en.json
@@ -2685,7 +2685,7 @@
 	"cube.rescale": "Rotation Rescale",
 	"cube.rescale.desc": "Rescale cube to compensate for the rotation angle",
 	"cube.shade_direction_override": "Shade Direction Override",
-	"cube.shade_direction_override.desc": "Defines the direction of the light source to cast a shading effect on the faces. If not specified, no shading will be applied. This does not affect ambient occlusion or shading based on light level.",
+	"cube.shade_direction_override.desc": "Shade every face of the cube as if it was facing this direction. If not set, each face is shaded based on the direction it actually faces. This does not affect ambient occlusion or shading based on light level.",
 	"cube.color.light_blue": "Light Blue",
 	"cube.color.yellow": "Yellow",
 	"cube.color.orange": "Orange",


### PR DESCRIPTION
`shade` and `shade_direction_override` are both available at the same time, which is not correct. Minecraft removed `shade` in 26.3 and replaced it with `shade_direction_override`.

This adds a `26.3` format version to control which one is used.