### PR TITLE
Fix texture meshes not rebuilding when changing the texture file

### DIFF
--- a/js/texturing/textures.js
+++ b/js/texturing/textures.js
@@ -119,7 +119,8 @@ export class Texture {
 			}
 			self.currentFrame = Math.min(self.currentFrame, (self.frameCount||1)-1)
 
-			if (img.update_from_canvas) {
+			let update_from_canvas = img.update_from_canvas;
+			if (update_from_canvas) {
 				delete img.update_from_canvas;
 			} else if (!self.layers_enabled) {
 				self.canvas.width = self.width;
@@ -191,6 +192,12 @@ export class Texture {
 					TextureAnimator.updateButton()
 					if (UVEditor.vue && UVEditor.vue.texture == this) UVEditor.vue.updateTexture()
 					Canvas.updateAllFaces(self)
+				} else if (!update_from_canvas) {
+					Outliner.elements.forEach(element => {
+						if (element instanceof TextureMesh) {
+							element.preview_controller.updateGeometry(element);
+						}
+					})
 				}
 				if (typeof self.load_callback === 'function') {
 					self.load_callback(self);


### PR DESCRIPTION
Changing the file of a texture that a texture mesh uses did not rebuild the mesh, so it kept the shape of the old image. This only happened when the new image was the same size as the old one.