### PR TITLE
Fix local plugins being uninstalled after a failed load

### DIFF
--- a/js/plugin_loader.ts
+++ b/js/plugin_loader.ts
@@ -519,14 +519,14 @@ export class Plugin {
 		this.tags.safePush('Local');
 
 		if (isApp) {
+			scope.path = file.path;
 			let content = await this.#runPluginFile(file.path).catch((error) => {
-				console.error(error);
+				console.error(`Could not load plugin "${scope.id}" from "${file.path}":`, error);
 			});
 			if (content) {
 				if (first && scope.oninstall) {
 					scope.oninstall()
 				}
-				scope.path = file.path;
 			}
 		} else {
 			this.#runCode(file.content as string);


### PR DESCRIPTION
When a local plugin fails to load once, it gets uninstalled on the next start and does not come back, even though the file itself is never touched.

`loadFromFile` only recorded the path after a successful load, but saved the installation entry either way, so a failed load left the entry with an empty path. On the next start that empty path fails the `fs.existsSync` check and the plugin is removed.