### PR TITLE
Add a parsed event so plugins can extend codec importing

### DIFF
--- a/js/io/codec.ts
+++ b/js/io/codec.ts
@@ -169,6 +169,8 @@ export class Codec extends EventSystem {
 
 		this.parse(model, file.path, args)
 
+		this.dispatchEvent('parsed', {model, path: file?.path, options: args, project: Project});
+
 		if (file.path && isApp && this.remember && !file.no_file ) {
 			loadDataFromModelMemory();
 			addRecentProject({

--- a/js/util/event_system.ts
+++ b/js/util/event_system.ts
@@ -1,21 +1,42 @@
-type EventListener = (data: any) => void;
+type EventListener = (data: any) => void | Promise<void>;
 type Deletable = {
 	delete(): void
 }
+
+const listener_origins = new WeakMap<EventListener, string>();
 
 export class EventSystem {
 	events: Record<string, EventListener[]>
 	constructor() {
 		this.events = {};
 	}
+	#reportListenerError(event_name: string, callback: EventListener, error: any) {
+		let origin = listener_origins.get(callback);
+		console.error(`Error in "${event_name}" listener${origin ? ` from plugin "${origin}"` : ''}:`, error);
+	}
 	dispatchEvent(event_name: string, data: any): any {
 		var list = this.events[event_name];
 		if (!list) return;
 		let return_value: any;
-		for (let callback of list) {
-			return_value = callback(data) ?? return_value;
+		for (let callback of list.slice()) {
+			try {
+				return_value = callback(data) ?? return_value;
+			} catch (error) {
+				this.#reportListenerError(event_name, callback, error);
+			}
 		}
 		return return_value;
+	}
+	async dispatchEventAsync(event_name: string, data: any): Promise<void> {
+		var list = this.events[event_name];
+		if (!list) return;
+		for (let callback of list.slice()) {
+			try {
+				await callback(data);
+			} catch (error) {
+				this.#reportListenerError(event_name, callback, error);
+			}
+		}
 	}
 	on(event_name: string, cb: EventListener): Deletable {
 		if (typeof cb !== 'function') {
@@ -43,6 +64,9 @@ export class EventSystem {
 				this.events[event_name] = [];
 			}
 			this.events[event_name].safePush(cb);
+			if (typeof Plugins != 'undefined' && Plugins.currently_loading) {
+				listener_origins.set(cb, Plugins.currently_loading);
+			}
 			return {
 				delete: () => {
 					this.events[event_name].remove(cb);


### PR DESCRIPTION
Plugins can already extend exporting, since every codec dispatches `compile` right before serialising and a listener can add to the model. Importing has no equivalent, because `parse` fires before the file is read. There is currently no way to react to the finished project while the original file data is still available.

This adds a `parsed` event, dispatched from `Codec.load` once `parse` returns, carrying the original data and the resulting project. Putting it in `load` means every codec gets it without needing to be changed.

Event listeners are now also isolated, so one plugin throwing does not stop the other listeners or break the import, and the error names the plugin it came from.

`dispatchEventAsync` is included for listeners that need to await, but `Codec.load` still uses the sync dispatch. Making the load path awaitable would change every `Codec.load` call site, so that felt worth deciding separately. `Codecs.project.parse` is also called directly in a couple of places, which bypasses `load` and so does not fire the event.
