### PR TITLE
Fix alt tools staying selected after switching modes

### DIFF
--- a/js/modes.ts
+++ b/js/modes.ts
@@ -79,6 +79,10 @@ export class Mode extends KeybindItem {
 	}
 	/**Selects the mode */
 	select() {
+		if (Toolbox.original instanceof Tool) {
+			Toolbox.original.select();
+			delete Toolbox.original;
+		}
 		if (Modes.selected instanceof Mode) {
 			Modes.selected.unselect();
 		}


### PR DESCRIPTION
Holding alt to temporarily swap to the alt tool writes that tool into the mode's remembered tool, because `Tool.select()` has no way to tell a temporary swap from a real one. Switching modes while alt is still held leaves it there, so the alt tool is force selected when you come back to the mode.

This restores the original tool before the mode switch.

Fixes #2192
