### PR TITLE
Fix custom skin poses being lost on project conversion

### DIFF
--- a/js/formats/bbmodel.js
+++ b/js/formats/bbmodel.js
@@ -274,6 +274,8 @@ var codec = new Codec('project', {
 				}
 				filterList(model.outliner);
 			}
+		} else {
+			model.skin_pose_data = Codecs.skin_model.getPoseData();
 		}
 
 		function handleAssetPath(object, key, relative_key) {
@@ -475,7 +477,7 @@ var codec = new Codec('project', {
 		}
 
 		if (model.skin_model) {
-			Codecs.skin_model.rebuild(model.skin_model, model.skin_pose);
+			Codecs.skin_model.rebuild(model.skin_model, model.skin_pose, model.skin_pose_data);
 		}
 		if (model.elements) {
 			let default_texture = Texture.getDefault();

--- a/js/formats/minecraft/skin.ts
+++ b/js/formats/minecraft/skin.ts
@@ -269,19 +269,23 @@ export const codec = new Codec('skin_model', {
 	},
 })
 codec.export = null;
-codec.rebuild = function(model_id: string, pose?: string) {
+codec.rebuild = function(model_id: string, pose?: string, pose_data?: SkinPoseData) {
 	let [preset_id, variant] = model_id.split('.');
 	let preset = skin_presets[preset_id];
 	let model_raw = preset.model || (variant == 'java' ? preset.model_java : preset.model_bedrock) || preset.variants[variant].model;
 	let model = JSON.parse(model_raw);
 	// @ts-ignore
 	codec.parse(model, undefined, true, pose && pose !== 'none');
-	if (pose && pose !== 'none' && pose !== 'natural') {
+	if (pose_data) {
+		loadPose(pose_data);
+		Panels.skin_pose.inside_vue.pose = Project.skin_pose = pose ?? '';
+	} else if (pose && pose !== 'none' && pose !== 'natural') {
 		setTimeout(() => {
 			setDefaultPose(pose);
 		}, 1)
 	}
 }
+codec.getPoseData = getPoseData;
 
 
 export const format = new ModelFormat('skin', {


### PR DESCRIPTION
Converting a skin project with Create Copy loses any pose you made by hand, snapping it back to whichever preset was selected. Saving to `.bbmodel` and reopening loses it the same way. Preset poses are unaffected.

This stores the pose data in the project so it survives. It adds a `skin_pose_data` field to saved projects.

Fixes #3091
