### PR TITLE
Fix drag and drop getting stuck when the window loses focus

### DIFF
--- a/js/interface/keyboard.js
+++ b/js/interface/keyboard.js
@@ -607,6 +607,10 @@ function isSwapToolsHoldKey(key) {
 }
 
 window.addEventListener('blur', event => {
+	let release = { bubbles: true, clientX: mouse_pos.x, clientY: mouse_pos.y };
+	document.dispatchEvent(new PointerEvent('pointerup', release));
+	document.dispatchEvent(new MouseEvent('mouseup', release));
+
 	if (isSwapToolsEnabled()) {
 		if (Toolbox.original && Toolbox.original.alt_tool) {
 			Toolbox.original.select()


### PR DESCRIPTION
Taking a screenshot with the snipping tool while dragging leaves the drag stuck to the cursor, even after letting go of the mouse button.

Drags end on a mouse release on the document. When another window takes focus the release never arrives, so the drag never ends.

Blur now dispatches a mouse release, which ends any drag in progress. The drop completes where the cursor last was rather than being cancelled.

Fixes #3466
