### PR TITLE
Fix config dialog forms leaking their colour pickers

### DIFF
--- a/js/interface/dialog.ts
+++ b/js/interface/dialog.ts
@@ -1104,7 +1104,11 @@ export class ConfigDialog extends Dialog {
 		return this;
 	}
 	build() {
-		if (this.object) this.object.remove();
+		if (this.object) {
+			this.form?.delete();
+			delete this.form;
+			this.object.remove();
+		}
 		this.object = document.createElement('dialog');
 		this.object.className = 'dialog config_dialog';
 
@@ -1162,6 +1166,8 @@ export class ConfigDialog extends Dialog {
 		return this;
 	}
 	delete() {
+		this.form?.delete();
+		delete this.form;
 		if (this.object) this.object.remove()
 		this.object = null;
 	}


### PR DESCRIPTION
`ConfigDialog` overrides `build()` and `delete()` without disposing the form, so rebuilding one orphans a spectrum container on the body every time, and deleting it leaves them behind. `ToolConfig` extends it, so tool configs leak too.

#3584 fixed this for `Dialog`, but these two overrides were missed.

Fixes #3567
