### PR TITLE
Fix tooltips clashing with open menus

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -627,7 +627,7 @@
 		color: var(--color-bright_ui_text);
 		margin-top: 30px;
 		white-space: nowrap;
-		z-index: 20;
+		z-index: 31;
 		box-shadow: 0 0.4px 3.5px rgba(0, 0, 0, 0.6);
 		border-radius: 4px;
 		pointer-events: none;
@@ -635,6 +635,9 @@
 	}
 	.tool:hover > .tooltip {
 		visibility: visible;
+	}
+	.tool.menu_open:hover > .tooltip {
+		visibility: hidden;
 	}
 	.tooltip_shift {
 		display: none;

--- a/js/interface/dialog.ts
+++ b/js/interface/dialog.ts
@@ -1087,10 +1087,15 @@ export class ConfigDialog extends Dialog {
 	constructor(id: string, options: ConfigDialogOptions) {
 		super(id, options);
 	}
+	anchor_tool?: HTMLElement
+
 	show(anchor?: HTMLElement) {
 		super.show()
 		$('#blackout').hide();
-		
+
+		this.anchor_tool = anchor instanceof HTMLElement ? anchor.closest('.tool') : null;
+		this.anchor_tool?.classList.add('menu_open');
+
 		if (anchor instanceof HTMLElement) {
 			let anchor_position = $(anchor).offset();
 			let left = Math.clamp(anchor_position.left - 30, 0, window.innerWidth-this.object.clientWidth - (this.title ? 0 : 30));
@@ -1102,6 +1107,11 @@ export class ConfigDialog extends Dialog {
 			this.object.style.left = left + 'px';
 		}
 		return this;
+	}
+	hide() {
+		this.anchor_tool?.classList.remove('menu_open');
+		this.anchor_tool = null;
+		return super.hide();
 	}
 	build() {
 		if (this.object) this.object.remove();

--- a/js/interface/menu.ts
+++ b/js/interface/menu.ts
@@ -127,6 +127,7 @@ export class Menu implements Deletable {
 	onClose?(): void
 	node: HTMLUListElement
 	highlight_action?: MenuItem
+	anchor_tool?: HTMLElement
 
 	public type = 'menu'
 
@@ -317,6 +318,9 @@ export class Menu implements Deletable {
 			open_menu.hide()
 		}
 		document.body.append(this.node);
+
+		this.anchor_tool = position instanceof HTMLElement ? position.closest('.tool') : null;
+		this.anchor_tool?.classList.add('menu_open');
 
 		ctxmenu.replaceChildren();
 
@@ -740,6 +744,8 @@ export class Menu implements Deletable {
 	 * Closes the menu if it's open
 	 */
 	hide(): this {
+		this.anchor_tool?.classList.remove('menu_open');
+		this.anchor_tool = null;
 		if (this.onClose) this.onClose();
 		$(this.node).find('li.highlighted').removeClass('highlighted');
 		this.node.remove()

--- a/js/interface/toolbars.ts
+++ b/js/interface/toolbars.ts
@@ -6,8 +6,6 @@
  * @module
  */
 
-import { MenuOpenPositionAnchor } from './menu'
-
 /**
  * Registry of all toolbars
  */
@@ -240,15 +238,7 @@ export class Toolbar {
 		return this;
 	}
 	contextmenu(event: MouseEvent) {
-		let offset = $(this.node).find('.toolbar_menu').offset();
-		let position: MenuOpenPositionAnchor = event;
-		if (offset) {
-			position = {
-				clientX: offset.left+7,
-				clientY: offset.top+28,
-			}
-		}
-		this.menu.open(position, this);
+		this.menu.open(this.node.querySelector<HTMLElement>('.toolbar_menu') ?? event, this);
 	}
 	editMenu(): this {
 		BARS.editing_bar = this;


### PR DESCRIPTION
Opening a menu from a toolbar button leaves that button's tooltip on screen, rendering behind the menu. Tooltips of other tools also render behind menus and config dialogs, so they get cut off instead of sitting on top.

Tooltips were on a lower z-index than menus and config dialogs, and nothing hid the tooltip of the tool a menu was opened from.

Tooltips now sit above both, and the tool a menu or config dialog is anchored to hides its own tooltip while it is open.

Toolbar menus were positioning themselves from hand written coordinates rather than passing their button, so they had no anchor to hide. They now pass the button like every other menu does.

Fixes #3468
