### PR TITLE
Fix double clicking a panel label not collapsing it

### DIFF
--- a/css/panels.css
+++ b/css/panels.css
@@ -114,7 +114,7 @@
 		letter-spacing: -0.5px;
 		text-transform: uppercase;
 		color: var(--color-subtle_text);
-		padding: 8px 10px;
+		padding: 0 10px;
 		border-top-left-radius: 5px;
 		border-top-right-radius: 5px;
 		cursor: pointer;
@@ -202,14 +202,14 @@
 	}*/
 	.panel_menu_button {
 		width: 25px;
-		height: 25px;
+		align-self: stretch;
 		float: none;
-		display: inline-block;
-		vertical-align: top;
-		text-align: center;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		cursor: pointer;
 		color: var(--color-subtle_text);
-		padding-top: 2px;
+		padding-bottom: 2px;
 		margin-right: -10px;
 	}
 	.panel_handle:not(.selected) .panel_menu_button {

--- a/js/interface/panels.ts
+++ b/js/interface/panels.ts
@@ -247,7 +247,8 @@ export class Panel extends EventSystem {
 				this.fold();
 			})
 
-			this.tab_bar.firstElementChild.addEventListener('dblclick', e => {
+			this.tab_bar.firstElementChild.addEventListener('click', (e: MouseEvent) => {
+				if (e.detail < 2 || e.detail % 2 || (e.target as HTMLElement).closest('.panel_menu_button')) return;
 				this.fold();
 			})
 
@@ -422,6 +423,9 @@ export class Panel extends EventSystem {
 					this.dispatchEvent('drag', {event: e2, target_before, attach_to, target_panel, target_slot});
 				}
 				let stop = e2 => {
+					removeEventListeners(document, 'mousemove touchmove', drag);
+					removeEventListeners(document, 'mouseup touchend', stop);
+					if (!started) return;
 					convertTouchEvent(e2);
 					this.container.classList.remove('dragging');
 					Interface.center_screen.removeAttribute('snapside');
@@ -449,9 +453,6 @@ export class Panel extends EventSystem {
 					setTimeout(() => {
 						this.update();
 					}, 0);
-					
-					removeEventListeners(document, 'mousemove touchmove', drag);
-					removeEventListeners(document, 'mouseup touchend', stop);
 				}
 				addEventListeners(document, 'mousemove touchmove', drag);
 				addEventListeners(document, 'mouseup touchend', stop);


### PR DESCRIPTION
Double clicking a panel label does not collapse it, it only works on the triple dot menu button.

The panel drag handler was eating the click events on the label.

Collapsing now uses the click count rather than the double click event, so collapsing and expanding again straight away works. The menu button also properly spans the full height of the handle, and now ignores the double click so using the menu does not toggle the panel's collapsed state.

Fixes #3727
