### PR TITLE
Fill in the bedrock display transform defaults

### DIFF
--- a/js/display_mode/display_mode.js
+++ b/js/display_mode/display_mode.js
@@ -994,10 +994,11 @@ DisplayMode.bedrock_defaults = {
 }
 DisplayMode.applyPreset = function(preset, all) {
 	if (preset == undefined) return;
+	let areas = (preset.id == 'block' && Format.id == 'bedrock_block') ? DisplayMode.bedrock_defaults : preset.areas;
 	var slots = [DisplayMode.display_slot];
 	if (all) {
 		slots = displayReferenceObjects.slots
-	} else if (preset.areas[DisplayMode.display_slot] == undefined) {
+	} else if (areas[DisplayMode.display_slot] == undefined) {
 		Blockbench.showQuickMessage('message.preset_no_info')
 		return;
 	};
@@ -1006,14 +1007,11 @@ DisplayMode.applyPreset = function(preset, all) {
 		if (!Project.display_settings[sl]) {
 			Project.display_settings[sl] = new DisplaySlot(sl)
 		}
-		let preset_values = preset.areas[sl];
+		let preset_values = areas[sl];
 		if (preset_values) {
 			if (!preset_values.rotation_pivot) Project.display_settings[sl].rotation_pivot.replace([0, 0, 0]);
 			if (!preset_values.scale_pivot) Project.display_settings[sl].scale_pivot.replace([0, 0, 0]);
-			Project.display_settings[sl].extend(preset.areas[sl]);
-			if (preset.id == 'block' && Format.id == 'bedrock_block' && sl == 'gui') {
-				Project.display_settings[sl].rotation[1] = 45;
-			}
+			Project.display_settings[sl].extend(preset_values);
 		}
 	})
 	DisplayMode.updateDisplayBase()

--- a/js/display_mode/display_mode.js
+++ b/js/display_mode/display_mode.js
@@ -979,6 +979,19 @@ DisplayMode.updateDisplayBase = function(slot) {
 }
 
 
+// Extracted from a Bedrock 1.26.50.27 APK
+DisplayMode.bedrock_defaults = {
+	gui:                   { translation: [0, 0, 0],   rotation: [30, 45, 0],  scale: [0.625, 0.625, 0.625], fit_to_frame: true },
+	firstperson_righthand: { translation: [0, 0, 0],   rotation: [0, 45, 0],   scale: [0.4, 0.4, 0.4] },
+	firstperson_lefthand:  { translation: [0, 0, 0],   rotation: [0, -135, 0], scale: [0.4, 0.4, 0.4] },
+	thirdperson_righthand: { translation: [0, 2.5, 0], rotation: [70, 45, 0],  scale: [0.375, 0.375, 0.375] },
+	thirdperson_lefthand:  { translation: [0, 2.5, 0], rotation: [70, 45, 0],  scale: [0.375, 0.375, 0.375] },
+	ground:                { translation: [0, 3, 0],   rotation: [0, 0, 0],    scale: [0.25, 0.25, 0.25] },
+	fixed:                 { translation: [0, 0, 0],   rotation: [0, 0, 0],    scale: [0.5, 0.5, 0.5] },
+	head:                  { translation: [0, 0, 0],   rotation: [0, 0, 0],    scale: [1, 1, 1] },
+	embedded:              { translation: [0, 0, 0],   rotation: [0, 0, 0],    scale: [0.75, 0.75, 0.75] },
+	on_shelf:              { translation: [0, 0, 0],   rotation: [0, 0, 0],    scale: [0.5, 0.5, 0.5] },
+}
 DisplayMode.applyPreset = function(preset, all) {
 	if (preset == undefined) return;
 	var slots = [DisplayMode.display_slot];
@@ -1006,10 +1019,12 @@ DisplayMode.applyPreset = function(preset, all) {
 	DisplayMode.updateDisplayBase()
 	Undo.finishEdit('Apply display preset')
 }
-DisplayMode.loadJSON = function(data) {
-	for (var slot in data) {
+DisplayMode.loadJSON = function(data, defaults) {
+	for (let slot in data) {
 		if (displayReferenceObjects.slots.includes(slot)) {
-			Project.display_settings[slot] = new DisplaySlot(slot).extend(data[slot])
+			let display_slot = new DisplaySlot(slot);
+			if (defaults && defaults[slot]) display_slot.extend(defaults[slot]);
+			Project.display_settings[slot] = display_slot.extend(data[slot]);
 		}
 	}
 }

--- a/js/formats/bedrock/bedrock.js
+++ b/js/formats/bedrock/bedrock.js
@@ -885,12 +885,7 @@ window.calculateVisibleBox = calculateVisibleBox;
 		}
 
 		if (data.object.item_display_transforms !== undefined) {
-			DisplayMode.loadJSON(data.object.item_display_transforms)
-			if (data.object.item_display_transforms.gui) {
-				if (data.object.item_display_transforms.gui.fit_to_frame == undefined) {
-					Project.display_settings.gui.fit_to_frame = true;
-				}
-			}
+			DisplayMode.loadJSON(data.object.item_display_transforms, DisplayMode.bedrock_defaults)
 		}
 
 		var bones = {}


### PR DESCRIPTION
Fixes #3361.

Display transforms now load properly. Bedrock fills in its own defaults for any property a geometry does not specify, so a slot that only set a rotation was loading with no translation and a scale of 1.

Default Block now works on the embedded slot. The preset had no values for it, so applying it did nothing.

I got the defaults from a 1.26.50.27 APK, as the ones in the Microsoft docs are wrong.