### PR TITLE
Fix pasting a mesh selection corrupting the project

### DIFF
--- a/js/copy_paste.js
+++ b/js/copy_paste.js
@@ -279,6 +279,7 @@ export const Clipbench = {
 
 			for (let old_fkey in this.faces) {
 				let old_face = this.faces[old_fkey];
+				if (!old_face.vertices.allAre(old_vkey => old_vertices.includes(old_vkey))) continue;
 				let new_face = new MeshFace(mesh, old_face);
 				Property.resetUniqueValues(MeshFace, new_face);
 				let new_face_vertices = new_face.vertices.map(old_vkey => {

--- a/js/copy_paste.js
+++ b/js/copy_paste.js
@@ -257,7 +257,7 @@ export const Clipbench = {
 		})
 		for (let fkey in mesh.faces) {
 			let face = mesh.faces[fkey];
-			if (face.isSelected(fkey)) {
+			if (face.isSelected(fkey) && face.vertices.allAre(vkey => this.vertices[vkey])) {
 				this.faces[fkey] = new MeshFace(null, face);
 			}
 		}


### PR DESCRIPTION
Fixes #2442.

Having a face selected and selecting vertices afterwards does not deselect it. Copying and pasting copies both the selected faces and vertices. If you try to paste a face that does not have all its vertices selected, it tries to create a face with missing vertices and crashes.

To reproduce:
1. Make a mesh and switch to vertex mode
2. Select three vertices and create a face
3. Select only two of those three vertices
4. Copy and paste

Faces are now only copied if all of their vertices are copied too, and pasting skips any face that is still missing one.
