### PR TITLE
Hide more gizmos in screenshots

### DIFF
--- a/js/modeling/mesh/knife_tool.js
+++ b/js/modeling/mesh/knife_tool.js
@@ -28,6 +28,7 @@ export class KnifeToolContext {
 
 		this.mesh_3d.add(this.points_mesh);
 		this.mesh_3d.add(this.lines_mesh);
+		Canvas.gizmos.push(this.points_mesh, this.lines_mesh);
 
 		this.unselect_listener = Blockbench.on('unselect_project', context => {
 			if (this == KnifeToolContext.current) {
@@ -533,6 +534,8 @@ export class KnifeToolContext {
 			this.mesh_3d.remove(this.points_mesh);
 			this.mesh_3d.remove(this.lines_mesh);
 		}
+		Canvas.gizmos.remove(this.points_mesh);
+		Canvas.gizmos.remove(this.lines_mesh);
 		delete this.mesh;
 		delete this.mesh_3d;
 		if (this.toast) this.toast.delete();
@@ -564,6 +567,8 @@ export class KnifeToolCubeContext {
 				color: Canvas.outlineMaterial.color
 			}),
 		);
+
+		Canvas.gizmos.push(this.preview_mesh, this.cross_mesh);
 
 		this.unselect_listener = Blockbench.on('unselect_project', context => {
 			if (this == KnifeToolContext.current) {
@@ -690,6 +695,8 @@ export class KnifeToolCubeContext {
 		if (this.preview_mesh.parent) {
 			this.preview_mesh.parent.remove(this.preview_mesh);
 		}
+		Canvas.gizmos.remove(this.preview_mesh);
+		Canvas.gizmos.remove(this.cross_mesh);
 		delete this.cube;
 		delete this.cross_mesh;
 		delete this.precross_meshview_mesh;

--- a/js/outliner/types/bounding_box.ts
+++ b/js/outliner/types/bounding_box.ts
@@ -344,7 +344,8 @@ export class BoundingBox extends OutlinerElement {
 	static behavior = {
 		movable: true,
 		resizable: true,
-		unique_name: false
+		unique_name: false,
+		hide_in_screenshot: true
 	}
 }
 

--- a/js/preview/canvas.js
+++ b/js/preview/canvas.js
@@ -464,6 +464,9 @@ export const Canvas = {
 			Outliner.elements.forEach(element => {
 				let {mesh} = element;
 				if (element.selected && mesh.outline) edit(mesh.outline);
+				if (mesh.vertex_points) edit(mesh.vertex_points);
+				if (mesh.pathLine) edit(mesh.pathLine);
+				if (mesh.spaceLine) edit(mesh.spaceLine);
 				if (mesh.grid_box) edit(mesh.grid_box);
 				if (element instanceof Locator) edit(mesh.children[0]);
 				if (element.getTypeBehavior('hide_in_screenshot')) edit(mesh);


### PR DESCRIPTION
Fixes #2740, the knife tool showing up in screenshots.

Also fixes the same thing for mesh vertex points, spline path and space lines, and bounding boxes.