### PR TITLE
Fix locators exporting twice to glTF

### DIFF
--- a/js/outliner/types/locator.js
+++ b/js/outliner/types/locator.js
@@ -123,6 +123,7 @@ new NodePreviewController(Locator, {
 		sprite.name = element.uuid;
 		sprite.type = element.type;
 		sprite.isElement = true;
+		sprite.no_export = true;
 		mesh.add(sprite);
 		mesh.sprite = sprite;
 


### PR DESCRIPTION
Fixes #3266.

The locator's sprite marker was being detected as the locator itself and duplicating the locator export in gltf exports.