### PR TITLE
Fix bedrock bone parent casing when the parent comes later

### DIFF
--- a/js/formats/bedrock/bedrock.js
+++ b/js/formats/bedrock/bedrock.js
@@ -834,7 +834,7 @@ window.calculateVisibleBox = calculateVisibleBox;
 				parent_group = match;
 			} else {
 				parent_list.forEach(function(ib) {
-					if (ib.name === b.parent) {
+					if (ib.name.toLowerCase() === b.parent.toLowerCase()) {
 						ib.children && ib.children.length ? ib.children.push(group) : ib.children = [group]
 					}
 				})


### PR DESCRIPTION
Follow up to aa069fb3, fixes #3652.

That covered parents before children, but not children before parents.