### PR TITLE
Paint bucket fill in UV editor

### DIFF
--- a/js/texturing/painter.js
+++ b/js/texturing/painter.js
@@ -589,6 +589,24 @@ export const Painter = {
 		let {element, offset} = Painter.current;
 		let {rect, uvFactorX, uvFactorY, w, h} = area;
 
+		// UV panel doesn't set element
+		// Look up element from click position
+		if (!element && UVEditor) {
+			let hit = UVEditor.findFaceAtUV(texture, x, y, uvFactorX, uvFactorY);
+			if (hit) {
+				if (fill_mode === 'face' || fill_mode === 'element') {
+					Painter.current.element = hit.element;
+					Painter.current.face = hit.faceKey;
+					element = hit.element;
+				} else if (fill_mode === 'color' || fill_mode === 'color_connected') {
+					let r = hit.region;
+					rect = [r.minX, r.minY, r.maxX, r.maxY];
+					w = r.maxX - r.minX;
+					h = r.maxY - r.minY;
+				}
+			}
+		}
+
 		if (Painter.erase_mode && (fill_mode === 'element' || fill_mode === 'face')) {
 			ctx.globalAlpha = b_opacity;
 			ctx.fillStyle = 'white';

--- a/js/uv/uv.js
+++ b/js/uv/uv.js
@@ -674,6 +674,60 @@ export const UVEditor = {
 		}
 		return matches;
 	},
+	// Find which element face is at a given pixel coordinate in texture space
+	findFaceAtUV(texture, x, y, uvFactorX, uvFactorY) {
+		let animOffset = texture.display_height * texture.currentFrame;
+
+		for (let cube of Cube.all.concat(Billboard.all)) {
+			for (let faceKey in cube.faces) {
+				let face = cube.faces[faceKey];
+				let faceTexture = face.getTexture();
+				if (!faceTexture || Painter.getTextureToEdit(faceTexture) !== texture) continue;
+
+				let uv = face.uv;
+				if (!uv) continue;
+
+				let minX = Math.floor(Math.min(uv[0], uv[2]) * uvFactorX);
+				let maxX = Math.ceil(Math.max(uv[0], uv[2]) * uvFactorX);
+				let minY = Math.floor(Math.min(uv[1], uv[3]) * uvFactorY) + animOffset;
+				let maxY = Math.ceil(Math.max(uv[1], uv[3]) * uvFactorY) + animOffset;
+
+				if (x >= minX && x < maxX && y >= minY && y < maxY) {
+					return { element: cube, faceKey, region: { minX, minY, maxX, maxY } };
+				}
+			}
+		}
+
+		for (let mesh of Mesh.all) {
+			for (let faceKey in mesh.faces) {
+				let face = mesh.faces[faceKey];
+				let faceTexture = face.getTexture();
+				if (!faceTexture || Painter.getTextureToEdit(faceTexture) !== texture) continue;
+				if (face.vertices.length < 3) continue;
+
+				let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+				for (let vkey in face.uv) {
+					let uv = face.uv[vkey];
+					minX = Math.min(minX, uv[0] * uvFactorX);
+					maxX = Math.max(maxX, uv[0] * uvFactorX);
+					minY = Math.min(minY, uv[1] * uvFactorY);
+					maxY = Math.max(maxY, uv[1] * uvFactorY);
+				}
+
+				minX = Math.floor(minX);
+				minY = Math.floor(minY) + animOffset;
+				maxX = Math.ceil(maxX);
+				maxY = Math.ceil(maxY) + animOffset;
+
+				let polygon = face.getSortedVertices().map(vkey => face.uv[vkey]);
+				if (pointInPolygon([x, y], polygon)) {
+					return { element: mesh, faceKey, region: { minX, minY, maxX, maxY } };
+				}
+			}
+		}
+
+		return null;
+	},
 	forCubes(cb) {
 		for (let element of Outliner.selected) {
 			if (element.getTypeBehavior('cube_faces')) {


### PR DESCRIPTION
Paint bucket fill now works when painting from the UV panel without a selected element.

- Added `UVEditor.findFaceAtUV()` to resolve the target element and face from click position
- The fill tool resolves which face is under the cursor by scanning all cube, billboard, and mesh UVs and forwards the hit to the existing fill logic
- All fill modes (face, element, color, color_connected) are supported

Originally implemented in JannisX11/hytale-blockbench-plugin#205