### PR TITLE
Fix exporting a collection as a project

### DIFF
--- a/js/formats/bbmodel.js
+++ b/js/formats/bbmodel.js
@@ -306,9 +306,11 @@ var codec = new Codec('project', {
 		}
 
 		let collections = [];
-		for (let collection of Collection.all) {
-			let copy = collection.getSaveCopy();
-			collections.push(copy);
+		if (!options.collection_only) {
+			for (let collection of Collection.all) {
+				let copy = collection.getSaveCopy();
+				collections.push(copy);
+			}
 		}
 		if (collections.length) model.collections = collections;
 

--- a/js/formats/bbmodel.js
+++ b/js/formats/bbmodel.js
@@ -202,6 +202,9 @@ var codec = new Codec('project', {
 			if (ModelProject.properties[key].export == false) continue;
 			ModelProject.properties[key].copy(Project, model)
 		}
+		if (options.collection_only && Format.model_identifier) {
+			model.model_identifier = options.collection_only.model_identifier;
+		}
 
 		if (Project.overrides) {
 			model.overrides = Project.overrides;


### PR DESCRIPTION
Fixes #3239 and #3240.

The exported file was using the project's identifier instead of the collection's, and was carrying every other collection in the project along with it.