### PR TITLE
Fix GLTF export not respecting the sidedness of some materials

### DIFF
--- a/js/lib/GLTFExporter.js
+++ b/js/lib/GLTFExporter.js
@@ -932,7 +932,7 @@ GLTFExporter.prototype = {
 					color: 0xffffff,
 					map: original.map,
 					transparent: true,
-					side: Canvas.getRenderSide(),
+					side: original.side,
 					alphaTest: 0.05
 				});
 				cachedMaterials[original.uuid] = material;


### PR DESCRIPTION
Exporting as GLTF ignores the "Render Sides" setting on the model's texture, when the material gets routed through `GLTFExporter.getLamberMaterial`. It currently uses `Canvas.getRenderSide()` for that part of the export instead. I'm not quite sure what part of the editor controls that, but this results in the wrong setting when exporting.

This change makes it so that the material created from that function uses the `side` setting of the original material.

Here's an example of the same model exported with latest `main` (left) vs with this PR (right). This is from https://modelviewer.dev/editor/, which shows that the material was marked as double-sided despite the Blockbench texture having Render Sides set to "Outside".

<img width="1618" height="474" alt="firefox_mE5s9rW6dS" src="https://github.com/user-attachments/assets/28215d78-6596-423e-b9ac-69bd493d433d" />

---

I wasn't sure if this qualifies as a minor fix or not (ie. for branch `patch` vs `next`). It feels like it is to me, but since this would impact anything exported as GLTF that isn't double-sided, I wasn't sure.