### PR TITLE
Rank settings search results by relevance

### DIFF
--- a/js/interface/settings_window.ts
+++ b/js/interface/settings_window.ts
@@ -10,10 +10,10 @@ import { Setting, SettingsProfile } from "./settings";
 function rankSearchMatch(text: string, word: string, field_rank: number): number {
 	let words = text.split(/[^a-z0-9]+/).filter(part => part);
 	let is_word = (part: string) => part.startsWith(word) && part.length - word.length <= 2;
-	if (text == word) return 12 + field_rank * 4 + 4;
-	if (is_word(words[0] ?? '')) return 12 + field_rank * 4 + 3;
-	if (text.startsWith(word)) return 12 + field_rank * 4 + 2;
-	if (words.some(is_word)) return 12 + field_rank * 4 + 1;
+	if (text == word) return 20 + field_rank * 4 + 4;
+	if (is_word(words[0] ?? '')) return 20 + field_rank * 4 + 3;
+	if (text.startsWith(word)) return 20 + field_rank * 4 + 2;
+	if (words.some(is_word)) return 20 + field_rank * 4 + 1;
 	if (words.some(part => part.startsWith(word))) return field_rank * 3 + 2;
 	if (words.some(part => part.endsWith(word))) return field_rank * 3 + 1;
 	if (text.includes(word)) return field_rank * 3;
@@ -244,10 +244,13 @@ onVueSetup(function() {
 							let setting = settings[key];
 							if (!Condition(setting.condition)) continue;
 							let fields: [string, number][] = [
-								[setting.name.toLowerCase(), 3],
-								[key.replace(/_/g, ' '), 2],
+								[setting.name.toLowerCase(), 4],
+								[key.replace(/_/g, ' '), 3],
 								[setting.description.toLowerCase(), 1]
 							];
+							if (setting.plugin) {
+								fields.push([((Plugins.all.find(plugin => plugin.id == setting.plugin)?.title ?? setting.plugin) + ' plugin').toLowerCase(), 2]);
+							}
 							let ranks = keywords.map(word => {
 								return Math.max(...fields.map(([text, field_rank]) => rankSearchMatch(text, word, field_rank)));
 							});

--- a/js/interface/settings_window.ts
+++ b/js/interface/settings_window.ts
@@ -7,6 +7,19 @@ import { Dialog } from "./dialog";
 import { MenuItem } from "./menu";
 import { Setting, SettingsProfile } from "./settings";
 
+function rankSearchMatch(text: string, word: string, field_rank: number): number {
+	let words = text.split(/[^a-z0-9]+/).filter(part => part);
+	let is_word = (part: string) => part.startsWith(word) && part.length - word.length <= 2;
+	if (text == word) return 12 + field_rank * 4 + 4;
+	if (is_word(words[0] ?? '')) return 12 + field_rank * 4 + 3;
+	if (text.startsWith(word)) return 12 + field_rank * 4 + 2;
+	if (words.some(is_word)) return 12 + field_rank * 4 + 1;
+	if (words.some(part => part.startsWith(word))) return field_rank * 3 + 2;
+	if (words.some(part => part.endsWith(word))) return field_rank * 3 + 1;
+	if (text.includes(word)) return field_rank * 3;
+	return 0;
+}
+
 BARS.defineActions(() => {
 	new Action('settings_window', {
 		icon: 'settings',
@@ -225,28 +238,25 @@ onVueSetup(function() {
 			computed: {
 				list() {
 					if (this.search_term) {
-						var keywords = this.search_term.toLowerCase().replace(/_/g, ' ').split(' ');
-						var items = {};
-						for (var key in settings) {
-							var setting = settings[key];
-							if (Condition(setting.condition)) {
-								var name = setting.name.toLowerCase();
-								var desc = setting.description.toLowerCase();
-								var missmatch = false;
-								for (var word of keywords) {
-									if (
-										!key.includes(word) &&
-										!name.includes(word) &&
-										!desc.includes(word)
-									) {
-										missmatch = true;
-									}
-								}
-								if (!missmatch) {
-									items[key] = setting;
-								}
-							}
+						let keywords = this.search_term.toLowerCase().replace(/_/g, ' ').split(' ').filter(word => word);
+						let matches: {key: string, setting: Setting, worst: number, total: number}[] = [];
+						for (let key in settings) {
+							let setting = settings[key];
+							if (!Condition(setting.condition)) continue;
+							let fields: [string, number][] = [
+								[setting.name.toLowerCase(), 3],
+								[key.replace(/_/g, ' '), 2],
+								[setting.description.toLowerCase(), 1]
+							];
+							let ranks = keywords.map(word => {
+								return Math.max(...fields.map(([text, field_rank]) => rankSearchMatch(text, word, field_rank)));
+							});
+							if (ranks.includes(0)) continue;
+							matches.push({key, setting, worst: Math.min(...ranks), total: ranks.reduce((a, b) => a + b, 0)});
 						}
+						matches.sort((a, b) => (b.worst - a.worst) || (b.total - a.total));
+						let items = {};
+						for (let match of matches) items[match.key] = match.setting;
 						return items;
 					} else {
 						return this.structure[this.open_category].items;


### PR DESCRIPTION
Searching the settings was not ranking by relevance at all. This adds a ranking system that sorts them properly.

Searching "snap" before:

1. Grid Resolution
2. Rectangle Selection: Nearest Edge
3. Animation Snap

After:

1. Animation Snap
2. Rectangle Selection: Nearest Edge
3. Grid Resolution

Animation Snap is the only one with it in the name. The other two only mention snapping in their descriptions.

Plugins can also be searched now, so you can find their settings by searching for their name.